### PR TITLE
Make daemon only listen for TCP connections on local interface

### DIFF
--- a/kwm/daemon.cpp
+++ b/kwm/daemon.cpp
@@ -285,7 +285,7 @@ bool KwmStartDaemon()
 
     SrvAddr.sin_family = AF_INET;
     SrvAddr.sin_port = htons(KwmDaemonPort);
-    SrvAddr.sin_addr.s_addr = 0;
+    SrvAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     std::memset(&SrvAddr.sin_zero, '\0', 8);
 
     if(bind(KwmSockFD, (struct sockaddr*)&SrvAddr, sizeof(struct sockaddr)) == -1)


### PR DESCRIPTION
If the daemon part of kwm binds its listening socket to all
available network interfaces, then anybody on the internet could
connect to it and maliciously control kwm. Listen only on the
loopback interface 127.0.0.1 instead. (Users who genuinely need
to control kwm from a different machine should set up an ssh
port-forwarding tunnel which will provide authentication and
encryption.)