### PR TITLE
Return a value from KwmDaemonHandleConnectionBG()

### DIFF
--- a/kwm/daemon.cpp
+++ b/kwm/daemon.cpp
@@ -45,6 +45,8 @@ void * KwmDaemonHandleConnectionBG(void *)
 {
     while(KwmDaemonIsRunning)
         KwmDaemonHandleConnection();
+
+    return NULL;
 }
 
 void KwmDaemonHandleConnection()


### PR DESCRIPTION
The function KwmDaemonHandleConnectionBG() has a void* return type,
as required for pthread_create() thread functions. Return a value when
the function exits, to avoid a compile warning. The value is used as
the thread's exit status; since we don't care about that, just return
NULL.