### PR TITLE
Rewrite makefile so it only rebuilds what is necessary

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,27 +1,37 @@
 DEBUG_BUILD=-DDEBUG_BUILD
 FRAMEWORKS=-framework ApplicationServices -framework Carbon -framework Cocoa
-SOURCE_FILES=kwm/kwm.cpp kwm/tree.cpp kwm/window.cpp kwm/display.cpp kwm/daemon.cpp
+KWM_SRCS=kwm/kwm.cpp kwm/tree.cpp kwm/window.cpp kwm/display.cpp kwm/daemon.cpp
+HOTKEYS_SRCS=kwm/hotkeys.cpp
+KWMC_SRCS=kwmc/kwmc.cpp
 BUILD_PATH=./bin
-BUILD_FLAGS=-O3 -lpthread -o $(BUILD_PATH)/kwm
+BUILD_FLAGS=-O3
+BINS=$(BUILD_PATH)/hotkeys.so $(BUILD_PATH)/kwm $(BUILD_PATH)/kwmc
 
-.PHONY: kwmc
+all: $(BINS)
 
-all: kwm kwmc
+# The 'install' target forces a rebuild from clean with the DEBUG_BUILD
+# variable clear so that we don't emit debug log messages.
+install: DEBUG_BUILD=
+install: clean $(BINS)
 
-make_bin:
+.PHONY: all clean install
+
+# This is an order-only dependency so that we create the directory if it
+# doesn't exist, but don't try to rebuild the binaries if they happen to
+# be older than the directory's timestamp.
+$(BINS): | $(BUILD_PATH)
+
+$(BUILD_PATH):
 	mkdir -p $(BUILD_PATH)
 
 clean:
 	rm -rf $(BUILD_PATH)
 
-hotkeys: make_bin
-	g++ ./kwm/hotkeys.cpp $(DEBUG_BUILD) -O3 -shared -o $(BUILD_PATH)/hotkeys.so
+$(BUILD_PATH)/hotkeys.so: $(HOTKEYS_SRCS)
+	g++ $^ $(DEBUG_BUILD) $(BUILD_FLAGS) -shared -o $@
 
-kwm: hotkeys make_bin
-	g++ $(SOURCE_FILES) $(DEBUG_BUILD) $(BUILD_FLAGS) $(FRAMEWORKS)
+$(BUILD_PATH)/kwm: $(KWM_SRCS)
+	g++ $^ $(DEBUG_BUILD) $(BUILD_FLAGS) -lpthread $(FRAMEWORKS) -o $@
 
-kwmc: make_bin
-	g++ ./kwmc/kwmc.cpp -o $(BUILD_PATH)/kwmc
-
-install: hotkeys make_bin
-	g++ $(SOURCE_FILES) $(BUILD_FLAGS) $(FRAMEWORKS)
+$(BUILD_PATH)/kwmc: $(KWMC_SRCS)
+	g++ $^ $(DEBUG_BUILD) $(BUILD_FLAGS) -o $@


### PR DESCRIPTION
The current makefile doesn't correctly define the dependencies of the
various binaries.  This means that if you run 'make' it will rebuild
everything even if no source files have changed.  Restructure the makefile
to define the dependencies so that we only build what we need to.

The key changes here are:
 * use an 'order-only dependency' for ./bin/ so we don't rebuild
   everything when the directory's timestamp changes
 * use the actual binary filenames rather than phony target names for
   the rules that build the binaries
 * mark that the binaries depend on the source files that go into them
 * use Make's automatic variables (like $^) to avoid repeating the
   list of source files in the rule itself