### PR TITLE
Create Kwm plist

### DIFF
--- a/kwm.plist
+++ b/kwm.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.koekeishiya.kwm</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/opt/kwm/bin/kwm</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>Sockets</key>
+    <dict>
+        <key>Listeners</key>
+        <dict>
+            <key>SockServiceName</key>
+            <string>3020</string>
+            <key>SockType</key>
+            <string>dgram</string>
+            <key>SockFamily</key>
+            <string>IPv4</string>
+        </dict>
+    </dict>
+
+</dict>
+</plist>


### PR DESCRIPTION
@koekeishiya @napcae

With discussion on #23 on creating a brew formula for kwm on the `devel-only tap` It would be nice to have Kwm start on login through the [launchd](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html) mechanism.

To test this locally update [line 9 of kwm.plist](https://github.com/a-morales/kwm/blob/create-plist/kwm.plist#L9) to be the full path of the executable on your machine. 
With that change, just link the plist file via `ln -sf full/path/to/kwm.plist ~/Library/LaunchAgents` then logout/login to have Kwm start automatically.

There is a way to specify the plist file through the [homebrew formula](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/mongodb.rb#L105) and that may be the preferred route