### PR TITLE
Unbroke hotkeys under Kotoeri.

### DIFF
--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -212,7 +212,7 @@ bool GetLayoutIndependentKeycode(std::string Key, CGKeyCode *Keycode)
 
 CFStringRef KeycodeToString(CGKeyCode KeyCode)
 {
-    TISInputSourceRef Keyboard = TISCopyCurrentKeyboardInputSource();
+    TISInputSourceRef Keyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
     CFDataRef Uchr = (CFDataRef)TISGetInputSourceProperty(Keyboard, kTISPropertyUnicodeKeyLayoutData);
     const UCKeyboardLayout *KeyboardLayout = (const UCKeyboardLayout*)CFDataGetBytePtr(Uchr);
 


### PR DESCRIPTION
kwm was crashing on launch for me when .kwmrc contained hotkey definitions.

## Issue/fix
`CopyCurrent*KeyboardInputSource` do not allow access to the unicode data, `CopyCurrent*KeyboardLayoutInputSource` do.