### PR TITLE
Do not focus window below cursor when focus follows mouse is disabled

### DIFF
--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -426,7 +426,8 @@ void UpdateActiveWindowList(screen_info *Screen)
         }
 
         DEBUG("UpdateActiveWindowList() Active Display Changed")
-        FocusWindowBelowCursor();
+        if(KwmFocusMode != FocusModeDisabled)
+            FocusWindowBelowCursor();
     }
     else
     {
@@ -439,7 +440,8 @@ void UpdateActiveWindowList(screen_info *Screen)
 
             Screen->ActiveSpace = CurrentSpace;
             DisplayIdentifier = CGSCopyManagedDisplayForSpace(CGSDefaultConnection, Screen->ActiveSpace);
-            FocusWindowBelowCursor();
+            if(KwmFocusMode != FocusModeDisabled)
+                FocusWindowBelowCursor();
         }
     }
 


### PR DESCRIPTION
When changing space kwm will focus the window below the cursor regardless of focus follows mouse being disabled.