### PR TITLE
refactored how borders are done

### DIFF
--- a/kwm/border.cpp
+++ b/kwm/border.cpp
@@ -24,13 +24,13 @@ std::string ConvertHexToRGBAString(int WindowID, int Color, int Width)
     return std::to_string(WindowID) + " r:" + rs + " g:" + gs + " b:" + bs + " a:" + as + " s:" + std::to_string(Width);
 }
 
-void ClearBorder(kwm_border &Border)
+void ClearBorder(kwm_border *Border)
 {
-    if(Border.Handle)
+    if(Border->Handle)
     {
         std::string Command = "clear";
-        fwrite(Command.c_str(), Command.size(), 1, Border.Handle);
-        fflush(Border.Handle);
+        fwrite(Command.c_str(), Command.size(), 1, Border->Handle);
+        fflush(Border->Handle);
     }
 }
 
@@ -47,15 +47,15 @@ kwm_time_point PerformUpdateBorderTimer(kwm_time_point Time)
     return NewBorderTime;
 }
 
-void CloseBorder(kwm_border &Border)
+void CloseBorder(kwm_border *Border)
 {
-    if(Border.Handle)
+    if(Border->Handle)
     {
         std::string Terminate = "quit";
-        fwrite(Terminate.c_str(), Terminate.size(), 1, Border.Handle);
-        fflush(Border.Handle);
-        pclose(Border.Handle);
-        Border.Handle = NULL;
+        fwrite(Terminate.c_str(), Terminate.size(), 1, Border->Handle);
+        fflush(Border->Handle);
+        pclose(Border->Handle);
+        Border->Handle = NULL;
     }
 }
 
@@ -99,7 +99,7 @@ void UpdateBorder(std::string BorderType)
         fflush(Border->Handle);
     }
     else if(WindowID == -1)
-        ClearBorder(*Border);
+        ClearBorder(Border);
     else
-        CloseBorder(*Border);
+        CloseBorder(Border);
 }

--- a/kwm/border.h
+++ b/kwm/border.h
@@ -5,7 +5,8 @@
 
 std::string ConvertHexToRGBAString(int WindowID, int Color, int Width);
 kwm_time_point PerformUpdateBorderTimer(kwm_time_point Time);
-void UpdateBorder(std::string Border);
-void ClearFocusedBorder();
+void CloseBorder(kwm_border &Border);
+void UpdateBorder(std::string BorderType);
+void ClearBorder(kwm_border &Border);
 
 #endif

--- a/kwm/border.h
+++ b/kwm/border.h
@@ -5,8 +5,8 @@
 
 std::string ConvertHexToRGBAString(int WindowID, int Color, int Width);
 kwm_time_point PerformUpdateBorderTimer(kwm_time_point Time);
-void CloseBorder(kwm_border &Border);
+void CloseBorder(kwm_border *Border);
 void UpdateBorder(std::string BorderType);
-void ClearBorder(kwm_border &Border);
+void ClearBorder(kwm_border *Border);
 
 #endif

--- a/kwm/display.cpp
+++ b/kwm/display.cpp
@@ -420,7 +420,7 @@ void GiveFocusToScreen(int ScreenIndex, tree_node *Focus, bool Mouse)
                 {
                     DEBUG("Space is floating")
                     ActivateScreen(Screen, Mouse);
-                    ClearBorder(FocusedBorder);
+                    ClearFocusedWindow();
                     return;
                 }
 

--- a/kwm/display.cpp
+++ b/kwm/display.cpp
@@ -1,13 +1,15 @@
+#include "border.h"
 #include "display.h"
 #include "space.h"
-#include "window.h"
 #include "tree.h"
+#include "window.h"
 
 extern kwm_screen KWMScreen;
 extern kwm_focus KWMFocus;
 extern kwm_tiling KWMTiling;
 extern kwm_thread KWMThread;
 extern kwm_toggles KWMToggles;
+extern kwm_border FocusedBorder;
 
 void DisplayReconfigurationCallBack(CGDirectDisplayID Display, CGDisplayChangeSummaryFlags Flags, void *UserInfo)
 {
@@ -418,7 +420,7 @@ void GiveFocusToScreen(int ScreenIndex, tree_node *Focus, bool Mouse)
                 {
                     DEBUG("Space is floating")
                     ActivateScreen(Screen, Mouse);
-                    ClearFocusedWindow();
+                    ClearBorder(FocusedBorder);
                     return;
                 }
 

--- a/kwm/display.cpp
+++ b/kwm/display.cpp
@@ -1,4 +1,3 @@
-#include "border.h"
 #include "display.h"
 #include "space.h"
 #include "tree.h"
@@ -9,7 +8,6 @@ extern kwm_focus KWMFocus;
 extern kwm_tiling KWMTiling;
 extern kwm_thread KWMThread;
 extern kwm_toggles KWMToggles;
-extern kwm_border FocusedBorder;
 
 void DisplayReconfigurationCallBack(CGDirectDisplayID Display, CGDisplayChangeSummaryFlags Flags, void *UserInfo)
 {

--- a/kwm/helpers.cpp
+++ b/kwm/helpers.cpp
@@ -40,16 +40,26 @@ std::vector<std::string> SplitString(std::string Line, char Delim)
 
 int ConvertStringToInt(std::string Integer)
 {
-    int SplitMode;
+    int IntResult;
     std::stringstream Stream(Integer);
-    Stream >> SplitMode;
-    return SplitMode;
+    Stream >> IntResult;
+    return IntResult;
 }
+
+unsigned int ConvertHexStringToInt(std::string HexString)
+{
+    unsigned int HexResult = 0xffffff;
+    std::stringstream Stream;
+    Stream << std::hex << HexString;
+    Stream >> HexResult;
+    return HexResult;
+}
+
 
 double ConvertStringToDouble(std::string Double)
 {
-    double SplitRatio;
+    double DoubleResult;
     std::stringstream Stream(Double);
-    Stream >> SplitRatio;
-    return SplitRatio;
+    Stream >> DoubleResult;
+    return DoubleResult;
 }

--- a/kwm/helpers.h
+++ b/kwm/helpers.h
@@ -9,5 +9,6 @@ std::vector<std::string> SplitString(std::string Line, char Delim);
 bool IsPrefixOfString(std::string &Line, std::string Prefix);
 int ConvertStringToInt(std::string Integer);
 double ConvertStringToDouble(std::string Double);
+unsigned int ConvertHexStringToInt(std::string Hex);
 
 #endif

--- a/kwm/interpreter.cpp
+++ b/kwm/interpreter.cpp
@@ -428,7 +428,7 @@ void KwmWindowCommand(std::vector<std::string> &Tokens)
             return;
 
         ToggleWindowFloating(Marked);
-        ClearBorder(&MarkedBorder);
+        ClearMarkedWindow();
         ToggleWindowFloating(Marked);
         MoveCursorToCenterOfFocusedWindow();
     }

--- a/kwm/interpreter.cpp
+++ b/kwm/interpreter.cpp
@@ -8,13 +8,17 @@
 #include "tree.h"
 #include "keys.h"
 #include "border.h"
+#include "types.h"
+#include "helpers.h"
 
 extern kwm_screen KWMScreen;
 extern kwm_toggles KWMToggles;
 extern kwm_focus KWMFocus;
 extern kwm_mode KWMMode;
 extern kwm_tiling KWMTiling;
-extern kwm_border KWMBorder;
+extern kwm_border FocusedBorder;
+extern kwm_border MarkedBorder;
+extern kwm_border PrefixBorder;
 extern kwm_hotkeys KWMHotkeys;
 
 // Command types
@@ -46,81 +50,60 @@ void KwmConfigCommand(std::vector<std::string> &Tokens)
     {
         if(Tokens[2] == "enable")
         {
-            KWMBorder.FEnabled = true;
+            FocusedBorder.Enabled = true;
         }
         else if(Tokens[2] == "disable")
         {
-            KWMBorder.FEnabled = false;
+            FocusedBorder.Enabled = false;
             UpdateBorder("focused");
         }
         else if(Tokens[2] == "size")
         {
-            int Width = 4;
-            std::stringstream Stream(Tokens[3]);
-            Stream >> Width;
-            KWMBorder.FWidth = Width;
+            FocusedBorder.Width = ConvertStringToInt(Tokens[3]);
         }
         else if(Tokens[2] == "color")
         {
-            unsigned int Color = 0xffffff;
-            std::stringstream Stream;
-            Stream << std::hex << Tokens[3];
-            Stream >> Color;
-            KWMBorder.FColor = Color;
+            FocusedBorder.Color = ConvertHexStringToInt(Tokens[3]);
         }
     }
     else if(Tokens[1] == "marked-border")
     {
         if(Tokens[2] == "enable")
         {
-            KWMBorder.MEnabled = true;
+            MarkedBorder.Enabled = true;
         }
         else if(Tokens[2] == "disable")
         {
-            KWMBorder.MEnabled = false;
+            MarkedBorder.Enabled = false;
             UpdateBorder("marked");
         }
         else if(Tokens[2] == "size")
         {
-            int Width = 4;
-            std::stringstream Stream(Tokens[3]);
-            Stream >> Width;
-            KWMBorder.MWidth = Width;
+            MarkedBorder.Width = ConvertStringToInt(Tokens[3]);
         }
         else if(Tokens[2] == "color")
         {
-            unsigned int Color = 0xffffff;
-            std::stringstream Stream;
-            Stream << std::hex << Tokens[3];
-            Stream >> Color;
-            KWMBorder.MColor = Color;
+            MarkedBorder.Color = ConvertHexStringToInt(Tokens[3]);
         }
     }
     else if(Tokens[1] == "hotkey-border")
     {
         if(Tokens[2] == "enable")
         {
-            KWMBorder.HEnabled = true;
+            PrefixBorder.Enabled = true;
         }
         else if(Tokens[2] == "disable")
         {
-            KWMBorder.HEnabled = false;
+            PrefixBorder.Enabled = false;
             UpdateBorder("focused");
         }
         else if(Tokens[2] == "size")
         {
-            int Width = 4;
-            std::stringstream Stream(Tokens[3]);
-            Stream >> Width;
-            KWMBorder.HWidth = Width;
+            PrefixBorder.Width = ConvertStringToInt(Tokens[3]);
         }
         else if(Tokens[2] == "color")
         {
-            unsigned int Color = 0xffffff;
-            std::stringstream Stream;
-            Stream << std::hex << Tokens[3];
-            Stream >> Color;
-            KWMBorder.HColor = Color;
+            PrefixBorder.Color = ConvertHexStringToInt(Tokens[3]);
         }
     }
 
@@ -445,7 +428,7 @@ void KwmWindowCommand(std::vector<std::string> &Tokens)
             return;
 
         ToggleWindowFloating(Marked);
-        ClearMarkedWindow();
+        ClearBorder(MarkedBorder);
         ToggleWindowFloating(Marked);
         MoveCursorToCenterOfFocusedWindow();
     }

--- a/kwm/interpreter.cpp
+++ b/kwm/interpreter.cpp
@@ -428,7 +428,7 @@ void KwmWindowCommand(std::vector<std::string> &Tokens)
             return;
 
         ToggleWindowFloating(Marked);
-        ClearBorder(MarkedBorder);
+        ClearBorder(&MarkedBorder);
         ToggleWindowFloating(Marked);
         MoveCursorToCenterOfFocusedWindow();
     }

--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -5,6 +5,8 @@
 
 extern kwm_focus KWMFocus;
 extern kwm_hotkeys KWMHotkeys;
+extern kwm_border FocusedBorder;
+extern kwm_border PrefixBorder;
 
 bool HotkeysAreEqual(hotkey *A, hotkey *B)
 {
@@ -35,6 +37,8 @@ bool KwmMainHotkeyTrigger(CGEventRef *Event)
     {
         KWMHotkeys.Prefix.Active = true;
         KWMHotkeys.Prefix.Time = std::chrono::steady_clock::now();
+        ClearBorder(FocusedBorder);
+        UpdateBorder("focused");
         return true;
     }
 
@@ -59,6 +63,7 @@ void CheckPrefixTimeout()
         if(Diff.count() > KWMHotkeys.Prefix.Timeout)
         {
             KWMHotkeys.Prefix.Active = false;
+            ClearBorder(PrefixBorder);
             UpdateBorder("focused");
         }
     }
@@ -213,6 +218,7 @@ void KwmSetPrefix(std::string KeySym)
     {
         KWMHotkeys.Prefix.Key = Hotkey;
         KWMHotkeys.Prefix.Active = false;
+        ClearBorder(PrefixBorder);
         KWMHotkeys.Prefix.Enabled = true;
     }
 }

--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -37,7 +37,7 @@ bool KwmMainHotkeyTrigger(CGEventRef *Event)
     {
         KWMHotkeys.Prefix.Active = true;
         KWMHotkeys.Prefix.Time = std::chrono::steady_clock::now();
-        ClearBorder(FocusedBorder);
+        ClearBorder(&FocusedBorder);
         UpdateBorder("focused");
         return true;
     }
@@ -63,7 +63,7 @@ void CheckPrefixTimeout()
         if(Diff.count() > KWMHotkeys.Prefix.Timeout)
         {
             KWMHotkeys.Prefix.Active = false;
-            ClearBorder(PrefixBorder);
+            ClearBorder(&PrefixBorder);
             UpdateBorder("focused");
         }
     }
@@ -218,7 +218,7 @@ void KwmSetPrefix(std::string KeySym)
     {
         KWMHotkeys.Prefix.Key = Hotkey;
         KWMHotkeys.Prefix.Active = false;
-        ClearBorder(PrefixBorder);
+        ClearBorder(&PrefixBorder);
         KWMHotkeys.Prefix.Enabled = true;
     }
 }

--- a/kwm/kwm.cpp
+++ b/kwm/kwm.cpp
@@ -107,9 +107,9 @@ CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef E
 
 void KwmQuit()
 {
-    CloseBorder(FocusedBorder);
-    CloseBorder(MarkedBorder);
-    CloseBorder(PrefixBorder);
+    CloseBorder(&FocusedBorder);
+    CloseBorder(&MarkedBorder);
+    CloseBorder(&PrefixBorder);
 
     exit(0);
 }
@@ -343,10 +343,9 @@ bool CheckArguments(int argc, char **argv)
 
 void SignalHandler(int Signum)
 {
-    std::string Terminate = "quit";
-    CloseBorder(FocusedBorder);
-    CloseBorder(MarkedBorder);
-    CloseBorder(PrefixBorder);
+    CloseBorder(&FocusedBorder);
+    CloseBorder(&MarkedBorder);
+    CloseBorder(&PrefixBorder);
 
     signal(Signum, SIG_DFL);
     kill(getpid(), Signum);

--- a/kwm/kwm.cpp
+++ b/kwm/kwm.cpp
@@ -21,7 +21,9 @@ kwm_tiling KWMTiling = {};
 kwm_cache KWMCache = {};
 kwm_thread KWMThread = {};
 kwm_hotkeys KWMHotkeys = {};
-kwm_border KWMBorder = {};
+kwm_border FocusedBorder = {};
+kwm_border MarkedBorder = {};
+kwm_border PrefixBorder = {};
 
 CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef Event, void *Refcon)
 {
@@ -90,7 +92,7 @@ CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef E
                 if(KWMToggles.EnableDragAndDrop && KWMToggles.DragInProgress)
                     KWMToggles.DragInProgress = false;
 
-                if(KWMFocus.Window && KWMBorder.FEnabled)
+                if(KWMFocus.Window && FocusedBorder.Enabled)
                 {
                     if(IsWindowFloating(KWMFocus.Window->WID, NULL))
                         UpdateBorder("focused");
@@ -105,21 +107,9 @@ CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef E
 
 void KwmQuit()
 {
-    if(KWMBorder.FHandle)
-    {
-        std::string Terminate = "quit";
-        fwrite(Terminate.c_str(), Terminate.size(), 1, KWMBorder.FHandle);
-        fflush(KWMBorder.FHandle);
-        pclose(KWMBorder.FHandle);
-    }
-
-    if(KWMBorder.MHandle)
-    {
-        std::string Terminate = "quit";
-        fwrite(Terminate.c_str(), Terminate.size(), 1, KWMBorder.MHandle);
-        fflush(KWMBorder.MHandle);
-        pclose(KWMBorder.MHandle);
-    }
+    CloseBorder(FocusedBorder);
+    CloseBorder(MarkedBorder);
+    CloseBorder(PrefixBorder);
 
     exit(0);
 }
@@ -354,19 +344,9 @@ bool CheckArguments(int argc, char **argv)
 void SignalHandler(int Signum)
 {
     std::string Terminate = "quit";
-    if(KWMBorder.FHandle)
-    {
-        fwrite(Terminate.c_str(), Terminate.size(), 1, KWMBorder.FHandle);
-        fflush(KWMBorder.FHandle);
-        pclose(KWMBorder.FHandle);
-    }
-
-    if(KWMBorder.MHandle)
-    {
-        fwrite(Terminate.c_str(), Terminate.size(), 1, KWMBorder.MHandle);
-        fflush(KWMBorder.MHandle);
-        pclose(KWMBorder.MHandle);
-    }
+    CloseBorder(FocusedBorder);
+    CloseBorder(MarkedBorder);
+    CloseBorder(PrefixBorder);
 
     signal(Signum, SIG_DFL);
     kill(getpid(), Signum);

--- a/kwm/space.cpp
+++ b/kwm/space.cpp
@@ -8,6 +8,8 @@ extern kwm_screen KWMScreen;
 extern kwm_focus KWMFocus;
 extern kwm_toggles KWMToggles;
 extern kwm_mode KWMMode;
+extern kwm_border FocusedBorder;
+extern kwm_border MarkedBorder;
 
 bool GetTagForCurrentSpace(std::string &Tag)
 {
@@ -25,7 +27,7 @@ bool GetTagForCurrentSpace(std::string &Tag)
             return true;
         }
 
-        tree_node *Node = Space->RootNode; 
+        tree_node *Node = Space->RootNode;
         bool FoundFocusedWindow = false;
         int FocusedIndex = 0;
         int NumberOfWindows = 0;
@@ -127,8 +129,8 @@ bool IsSpaceTransitionInProgress()
         DEBUG("IsSpaceTransitionInProgress() Space transition detected")
         KWMScreen.Transitioning = true;
         KWMScreen.UpdateSpace = true;
-        ClearFocusedWindow();
-        ClearMarkedWindow();
+        ClearBorder(FocusedBorder);
+        ClearBorder(MarkedBorder);
     }
 
     return Result;
@@ -161,7 +163,7 @@ void FloatFocusedSpace()
         DestroyNodeTree(Space->RootNode, Space->Mode);
         Space->RootNode = NULL;
         Space->Mode = SpaceModeFloating;
-        ClearFocusedWindow();
+        ClearBorder(FocusedBorder);
     }
 }
 

--- a/kwm/space.cpp
+++ b/kwm/space.cpp
@@ -129,8 +129,8 @@ bool IsSpaceTransitionInProgress()
         DEBUG("IsSpaceTransitionInProgress() Space transition detected")
         KWMScreen.Transitioning = true;
         KWMScreen.UpdateSpace = true;
-        ClearBorder(FocusedBorder);
-        ClearBorder(MarkedBorder);
+        ClearFocusedWindow();
+        ClearMarkedWindow();
     }
 
     return Result;
@@ -163,7 +163,7 @@ void FloatFocusedSpace()
         DestroyNodeTree(Space->RootNode, Space->Mode);
         Space->RootNode = NULL;
         Space->Mode = SpaceModeFloating;
-        ClearBorder(FocusedBorder);
+        ClearFocusedWindow();
     }
 }
 

--- a/kwm/types.h
+++ b/kwm/types.h
@@ -192,23 +192,11 @@ struct kwm_mach
 
 struct kwm_border
 {
-    FILE *FHandle;
-    FILE *MHandle;
-    bool FEnabled;
-    bool MEnabled;
-    bool HEnabled;
-
-    int FWidth;
-    unsigned int FColor;
-    kwm_time_point FTime;
-
-    int MWidth;
-    unsigned int MColor;
-    kwm_time_point MTime;
-
-    int HWidth;
-    unsigned int HColor;
-    kwm_time_point HTime;
+    bool Enabled;
+    FILE *Handle;
+    int Width;
+    unsigned int Color;
+    kwm_time_point Time;
 };
 
 struct kwm_prefix
@@ -221,6 +209,7 @@ struct kwm_prefix
     bool Active;
     bool Global;
 };
+
 
 struct kwm_hotkeys
 {

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -75,8 +75,8 @@ bool FilterWindowList(screen_info *Screen)
         {
                 Result = false;
                 KWMScreen.UpdateSpace = true;
-                ClearBorder(FocusedBorder);
-                ClearBorder(MarkedBorder);
+                ClearFocusedWindow();
+                ClearMarkedWindow();
                 return Result;
         }
 
@@ -225,6 +225,13 @@ int GetFocusedWindowID()
     return -1;
 }
 
+void ClearFocusedWindow()
+{
+  ClearBorder(&FocusedBorder);
+  KWMFocus.Window = NULL;
+  KWMFocus.Cache = KWMFocus.NULLWindowInfo;
+}
+
 bool FocusWindowOfOSX()
 {
     int WindowID;
@@ -352,7 +359,7 @@ void UpdateWindowTree()
                 DestroyNodeTree(KWMScreen.Current->Space[KWMScreen.Current->ActiveSpace].RootNode,
                                 KWMScreen.Current->Space[KWMScreen.Current->ActiveSpace].Mode);
                 KWMScreen.Current->Space[KWMScreen.Current->ActiveSpace].RootNode = NULL;
-                ClearBorder(FocusedBorder);
+                ClearFocusedWindow();
             }
         }
     }
@@ -392,7 +399,7 @@ void UpdateActiveWindowList(screen_info *Screen)
     {
         DEBUG("UpdateActiveWindowList() Active Display Changed")
         GiveFocusToScreen(Screen->ID, NULL, true);
-        ClearBorder(MarkedBorder);
+        ClearMarkedWindow();
 
         if(Screen->ForceSpaceUpdate)
         {
@@ -518,7 +525,7 @@ void ShouldBSPTreeUpdate(screen_info *Screen, space_info *Space)
     }
     else if(KWMTiling.WindowLst.size() < Screen->OldWindowListCount)
     {
-        ClearBorder(FocusedBorder);
+        ClearFocusedWindow();
         DEBUG("ShouldBSPTreeUpdate() Remove Window")
         std::vector<int> WindowIDsInTree;
 
@@ -589,7 +596,7 @@ void AddWindowToBSPTree(screen_info *Screen, int WindowID)
     else
     {
         CurrentNode = GetNodeFromWindowID(RootNode, KWMScreen.MarkedWindow, Space->Mode);
-        ClearBorder(MarkedBorder);
+        ClearMarkedWindow();
     }
 
     if(CurrentNode)
@@ -803,7 +810,7 @@ void AddWindowToTreeOfUnfocusedMonitor(screen_info *Screen, window_info *Window)
         return;
 
     if(Window->WID == KWMScreen.MarkedWindow)
-        ClearBorder(MarkedBorder);
+        ClearMarkedWindow();
 
     if(!IsSpaceInitializedForScreen(Screen))
     {
@@ -969,7 +976,7 @@ void SwapFocusedWindowWithMarked()
         }
     }
 
-    ClearBorder(MarkedBorder);
+    ClearMarkedWindow();
 }
 
 void SwapFocusedWindowWithNearest(int Shift)
@@ -1242,6 +1249,12 @@ void MoveCursorToCenterOfFocusedWindow()
         MoveCursorToCenterOfWindow(KWMFocus.Window);
 }
 
+void ClearMarkedWindow()
+{
+    KWMScreen.MarkedWindow = -1;
+    ClearBorder(&MarkedBorder);
+}
+
 void MarkWindowContainer()
 {
     if(KWMFocus.Window)
@@ -1249,7 +1262,7 @@ void MarkWindowContainer()
         if(KWMScreen.MarkedWindow == KWMFocus.Window->WID)
         {
             DEBUG("MarkWindowContainer() Unmarked " << KWMFocus.Window->Name)
-            ClearBorder(MarkedBorder);
+            ClearMarkedWindow();
         }
         else
         {

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -227,9 +227,9 @@ int GetFocusedWindowID()
 
 void ClearFocusedWindow()
 {
-  ClearBorder(&FocusedBorder);
-  KWMFocus.Window = NULL;
-  KWMFocus.Cache = KWMFocus.NULLWindowInfo;
+    ClearBorder(&FocusedBorder);
+    KWMFocus.Window = NULL;
+    KWMFocus.Cache = KWMFocus.NULLWindowInfo;
 }
 
 bool FocusWindowOfOSX()

--- a/kwm/window.h
+++ b/kwm/window.h
@@ -16,9 +16,9 @@ bool IsWindowBelowCursor(window_info *Window);
 bool IsWindowOnActiveSpace(int WindowID);
 bool WindowsAreEqual(window_info *Window, window_info *Match);
 
-void ClearFocusedWindow();
 bool ShouldWindowGainFocus(window_info *Window);
 bool GetWindowFocusedByOSX(int *WindowWID);
+int GetFocusedWindowID();
 bool FocusWindowOfOSX();
 void FocusWindowBelowCursor();
 void FocusFirstLeafNode();
@@ -58,7 +58,6 @@ double GetWindowDistance(window_info *A, window_info *B);
 void GetCenterOfWindow(window_info *Window, int *X, int *Y);
 bool WindowIsInDirection(window_info *A, window_info *B, int Degrees, bool Wrap);
 
-void ClearMarkedWindow();
 void MarkWindowContainer();
 
 void SetWindowRefFocus(AXUIElementRef WindowRef, window_info *Window);

--- a/kwm/window.h
+++ b/kwm/window.h
@@ -16,6 +16,7 @@ bool IsWindowBelowCursor(window_info *Window);
 bool IsWindowOnActiveSpace(int WindowID);
 bool WindowsAreEqual(window_info *Window, window_info *Match);
 
+void ClearFocusedWindow();
 bool ShouldWindowGainFocus(window_info *Window);
 bool GetWindowFocusedByOSX(int *WindowWID);
 int GetFocusedWindowID();
@@ -58,6 +59,7 @@ double GetWindowDistance(window_info *A, window_info *B);
 void GetCenterOfWindow(window_info *Window, int *X, int *Y);
 bool WindowIsInDirection(window_info *A, window_info *B, int Degrees, bool Wrap);
 
+void ClearMarkedWindow();
 void MarkWindowContainer();
 
 void SetWindowRefFocus(AXUIElementRef WindowRef, window_info *Window);


### PR DESCRIPTION
Refactored the Borders to be individual `kwm_border` structs `FocusedBorder`, `MarkedBorder` and `PrefixBorder`. I also removed the specific `ClearMarkedWindow`, `ClearFocusedWindow` and some repeated code to quit `kwm-overlay` to a more general `ClearBorder` and `CloseBorder` methods 