### PR TITLE
Update border offset logic to use line width

### DIFF
--- a/kwm-overlay/kwm-overlay.swift
+++ b/kwm-overlay/kwm-overlay.swift
@@ -8,7 +8,7 @@ func trim(str: String) -> String {
 
 }
 
-func parseFrame(args: Array<String>) -> NSRect
+func parseFrame(args: Array<String>, strokeWidth: Int) -> NSRect
 {
     var frameHash = [String: Int]()
     frameHash["w"] = 0
@@ -71,7 +71,10 @@ func parseFrame(args: Array<String>) -> NSRect
         }
     }
 
-    return NSRect(x: frameHash["x"]! - 1, y: frameHash["y"]! - 1, width: frameHash["w"]! + 2, height: frameHash["h"]! + 2)
+    return NSRect(x: frameHash["x"]! - (strokeWidth / 2),
+                  y: frameHash["y"]! - (strokeWidth / 2),
+                  width: frameHash["w"]! + strokeWidth,
+                  height: frameHash["h"]! + strokeWidth)
 }
 
 func parseColor(args: Array<String>) -> NSColor
@@ -179,9 +182,9 @@ class OverlayController: NSObject, NSApplicationDelegate
 
     func showOverlayView(args: Array<String>)
     {
-        let overlayFrame = parseFrame(args)
         let overlayColor = parseColor(args)
         let overlayWidth = parseWidth(args)
+        let overlayFrame = parseFrame(args, strokeWidth: Int(overlayWidth))
         let overlayView = OverlayView(frame: overlayFrame, color: overlayColor, width: overlayWidth)
 
         window.contentView = overlayView


### PR DESCRIPTION
This updates the border offset depending on the width of the stroke to account for wide border widths. 