### PR TITLE
makefile: Don't error if kwmrc already exists

### DIFF
--- a/makefile
+++ b/makefile
@@ -45,4 +45,4 @@ $(BUILD_PATH)/kwm_template.plist: $(KWM_PLIST)
 
 $(CONFIG_DIR)/kwmrc: $(SAMPLE_CONFIG)
 	mkdir -p $(CONFIG_DIR)
-	test ! -e $@ && cp -n $^ $@
+	if test ! -e $@; then cp -n $^ $@; else yes ; fi


### PR DESCRIPTION
Change shell `&&` test to `if` test to avoid spurious error exit.

I figure most people using kwm probably already have a kwmrc that they've lovingly crafted after some use, so it probably shouldn't be an error state after a `git pull && make clean && make` for the file to already exist. :)

Before:

```
mkdir -p /Users/mparks/.kwm
test ! -e /Users/mparks/.kwm/kwmrc && cp -n examples/kwmrc /Users/mparks/.kwm/kwmrc
make: *** [/Users/mparks/.kwm/kwmrc] Error 1
```

After: (no output unless the file was created)
