### PR TITLE
Create init file for Kwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ a variety of settings, as well as run any command not restricted to *Kwmc*.
 *Kwm* can apply all of these settings during runtime, and so live testing of options is possible
 before writing them into the config file.
 
-A sample config can be found within the [examples](examples) directory.
+In addition to the above, the file `$HOME/.kwm/init` is a shell script that will be ran after
+*Kwm* has finished setting up the internal configuration.
+
+A sample config and init file can be found within the [examples](examples) directory.
 
 ## Usage:
 

--- a/examples/init
+++ b/examples/init
@@ -1,0 +1,18 @@
+/usr/local/bin/kwmc space -s id 1
+sleep 1
+/usr/local/bin/kwmc space -t bsp
+
+/usr/local/bin/kwmc space -s id 2
+sleep 1
+/usr/local/bin/kwmc space -t monocle
+
+/usr/local/bin/kwmc space -s id 3
+sleep 1
+/usr/local/bin/kwmc space -t bsp
+
+/usr/local/bin/kwmc space -s id 4
+sleep 1
+/usr/local/bin/kwmc space -t float
+
+/usr/local/bin/kwmc space -s id 1
+sleep 1

--- a/kwm/kwm.cpp
+++ b/kwm/kwm.cpp
@@ -23,6 +23,7 @@ kwm_hotkeys KWMHotkeys = {};
 kwm_border FocusedBorder = {};
 kwm_border MarkedBorder = {};
 kwm_border PrefixBorder = {};
+kwm_callback KWMCallback =  {};
 
 CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef Event, void *Refcon)
 {
@@ -162,8 +163,18 @@ void KwmExecuteConfig()
     }
 
     KWMPath.EnvHome = HomeP;
+    KWMPath.ConfigFile = "kwmrc";
     KWMPath.ConfigFolder = ".kwm";
     KwmExecuteFile(KWMPath.ConfigFile);
+}
+
+void KwmExecuteInitScript()
+{
+    std::string InitFile = KWMPath.EnvHome + "/" + KWMPath.ConfigFolder + "/init";
+
+    struct stat Buffer;
+    if(stat(InitFile.c_str(), &Buffer) == 0)
+        KwmExecuteThreadedSystemCommand(InitFile);
 }
 
 void KwmExecuteFile(std::string File)
@@ -272,11 +283,10 @@ void KwmInit()
     MarkedBorder.Radius = -1;
     PrefixBorder.Radius = -1;
 
-    KWMPath.ConfigFile = "kwmrc";
     GetKwmFilePath();
-
     KwmExecuteConfig();
     GetActiveDisplays();
+    KwmExecuteInitScript();
 
     pthread_create(&KWMThread.WindowMonitor, NULL, &KwmWindowMonitor, NULL);
 }

--- a/kwm/kwm.h
+++ b/kwm/kwm.h
@@ -13,6 +13,7 @@ void KwmExecuteThreadedSystemCommand(std::string Command);
 
 void KwmExecuteSystemCommand(std::string Command);
 void KwmExecuteConfig();
+void KwmExecuteInitScript();
 void KwmExecuteFile(std::string File);
 void KwmReloadConfig();
 void KwmClearSettings();

--- a/kwm/space.cpp
+++ b/kwm/space.cpp
@@ -104,7 +104,7 @@ space_info *GetActiveSpaceOfScreen(screen_info *Screen)
     }
     else
     {
-        Space = &It->second;
+        Space = &Screen->Space[Screen->ActiveSpace];
     }
 
     return Space;
@@ -171,13 +171,17 @@ void FloatFocusedSpace()
 {
     if(KWMToggles.EnableTilingMode &&
        !IsSpaceTransitionInProgress() &&
-       IsActiveSpaceManaged() &&
-       FilterWindowList(KWMScreen.Current))
+       IsActiveSpaceManaged())
     {
         space_info *Space = GetActiveSpaceOfScreen(KWMScreen.Current);
+        if(Space->Mode == SpaceModeFloating)
+            return;
+
         DestroyNodeTree(Space->RootNode, Space->Mode);
         Space->RootNode = NULL;
+
         Space->Mode = SpaceModeFloating;
+        Space->Initialized = true;
         ClearFocusedWindow();
     }
 }

--- a/kwm/space.cpp
+++ b/kwm/space.cpp
@@ -169,8 +169,7 @@ void ShouldActiveSpaceBeManaged()
 
 void FloatFocusedSpace()
 {
-    if(IsSpaceInitializedForScreen(KWMScreen.Current) &&
-       KWMToggles.EnableTilingMode &&
+    if(KWMToggles.EnableTilingMode &&
        !IsSpaceTransitionInProgress() &&
        IsActiveSpaceManaged() &&
        FilterWindowList(KWMScreen.Current))
@@ -185,8 +184,7 @@ void FloatFocusedSpace()
 
 void TileFocusedSpace(space_tiling_option Mode)
 {
-    if(IsSpaceInitializedForScreen(KWMScreen.Current) &&
-       KWMToggles.EnableTilingMode &&
+    if(KWMToggles.EnableTilingMode &&
        !IsSpaceTransitionInProgress() &&
        IsActiveSpaceManaged() &&
        FilterWindowList(KWMScreen.Current))
@@ -206,11 +204,8 @@ void TileFocusedSpace(space_tiling_option Mode)
 
 void ToggleFocusedSpaceFloating()
 {
-    if(IsSpaceInitializedForScreen(KWMScreen.Current))
-    {
-        if(!IsSpaceFloating(KWMScreen.Current->ActiveSpace))
-            FloatFocusedSpace();
-        else
-            TileFocusedSpace(SpaceModeBSP);
-    }
+    if(!IsSpaceFloating(KWMScreen.Current->ActiveSpace))
+        FloatFocusedSpace();
+    else
+        TileFocusedSpace(SpaceModeBSP);
 }

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -309,7 +309,7 @@ void UpdateWindowTree()
         std::vector<window_info*> WindowsOnDisplay = GetAllWindowsOnDisplay(KWMScreen.Current->ID);
         space_info *Space = GetActiveSpaceOfScreen(KWMScreen.Current);
 
-        if(!IsSpaceFloating(KWMScreen.Current->ActiveSpace))
+        if(!IsActiveSpaceFloating())
         {
             if(!Space->Initialized &&
                !WindowsOnDisplay.empty())

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -217,9 +217,8 @@ bool FocusWindowOfOSX()
     if(GetWindowFocusedByOSX(&WindowID))
     {
         if(IsSpaceTransitionInProgress() ||
-           !IsActiveSpaceManaged() ||
-           !IsSpaceInitializedForScreen(KWMScreen.Current))
-                return false;
+           !IsActiveSpaceManaged())
+            return false;
 
         for(std::size_t WindowIndex = 0; WindowIndex < KWMTiling.WindowLst.size(); ++WindowIndex)
         {


### PR DESCRIPTION
This adds the functionality of an init file. The init file is a shell script that will be ran after Kwm has finished setting up the internal configuration.

The provided sample init file, uses the `kwmc space -s num` command to select a default tiling mode for individual spaces when Kwm starts.