### PR TITLE
Add extra rpath to overlay build.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 DEBUG_BUILD=-DDEBUG_BUILD -g
 FRAMEWORKS=-framework ApplicationServices -framework Carbon -framework Cocoa
+XTRA_RPATH=/Library/Developer/CommandLineTools/usr/lib/swift/macosx/
 SDK_ROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
 KWM_SRCS=kwm/kwm.cpp kwm/tree.cpp kwm/window.cpp kwm/display.cpp kwm/daemon.cpp kwm/interpreter.cpp kwm/keys.cpp kwm/space.cpp kwm/border.cpp kwm/notifications.cpp kwm/helpers.cpp kwm/workspace.mm
 KWMC_SRCS=kwmc/kwmc.cpp kwmc/help.cpp
@@ -37,7 +38,7 @@ $(BUILD_PATH)/kwmc: $(KWMC_SRCS)
 	g++ $^ $(BUILD_FLAGS) -o $@
 
 $(BUILD_PATH)/kwm-overlay: $(KWMO_SRCS)
-	swiftc -sdk $(SDK_ROOT) $^ -o $@
+	swiftc -sdk $(SDK_ROOT) -Xlinker -rpath -Xlinker $(XTRA_RPATH) -o $@ $^
 
 $(BUILD_PATH)/kwm_template.plist: $(KWM_PLIST)
 	cp $^ $@


### PR DESCRIPTION
I have solved (at least partially) the overlay not working if xcode isn't installed. 

Very unfortunately  `xcode-select --install` must still be ran in order for the rpath to be correct. But that is apart of `homebrew`s install process so it shouldn't be _that_ huge of a deal. 

If we wanted to remove the `xcode-select` dependency we would have to bundle the dylibs with `kwm` and update the rpath to point to wherever kwm is installed, which is far from ideal. 

This should allow the overlay to work for people who have `xcode-select` installed but NOT xcode.  

Fixes #182 
Fixes #175 