### PR TITLE
Sync osx focus and revise hotkey logic

### DIFF
--- a/kwm/display.h
+++ b/kwm/display.h
@@ -22,7 +22,7 @@ void MoveWindowToDisplay(window_info *Window, int Shift, bool Relative, bool Upd
 
 void SetSpaceModeOfDisplay(unsigned int ScreenIndex, std::string Mode);
 space_tiling_option GetSpaceModeOfDisplay(unsigned int ScreenIndex);
-void GiveFocusToScreen(int ScreenIndex, tree_node *Focus, bool Mouse);
+void GiveFocusToScreen(unsigned int ScreenIndex, tree_node *Focus, bool Mouse, bool UpdateFocus);
 void UpdateActiveScreen();
 
 container_offset CreateDefaultScreenOffset();

--- a/kwm/interpreter.cpp
+++ b/kwm/interpreter.cpp
@@ -618,11 +618,11 @@ void KwmScreenCommand(std::vector<std::string> &Tokens)
     if(Tokens[1] == "-f")
     {
         if(Tokens[2] == "prev")
-            GiveFocusToScreen(GetIndexOfPrevScreen(), NULL, false);
+            GiveFocusToScreen(GetIndexOfPrevScreen(), NULL, false, true);
         else if(Tokens[2] == "next")
-            GiveFocusToScreen(GetIndexOfNextScreen(), NULL, false);
+            GiveFocusToScreen(GetIndexOfNextScreen(), NULL, false, true);
         else
-            GiveFocusToScreen(ConvertStringToInt(Tokens[2]), NULL, false);
+            GiveFocusToScreen(ConvertStringToInt(Tokens[2]), NULL, false, true);
     }
     else if(Tokens[1] == "-s")
     {

--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -43,8 +43,10 @@ void *KwmMainHotkeyTrigger(void *HotkeyPtr)
             hotkey Hotkey = KWMHotkeys.Queue.front();
             KWMHotkeys.Queue.pop();
 
+            pthread_mutex_lock(&KWMThread.Lock);
             if(ShouldKeyBeProcessed(&Hotkey))
                 KwmExecuteHotkey(&Hotkey);
+            pthread_mutex_unlock(&KWMThread.Lock);
         }
 
         usleep(10000);

--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -24,27 +24,33 @@ bool HotkeysAreEqual(hotkey *A, hotkey *B)
     return false;
 }
 
-bool KwmMainHotkeyTrigger(CGEventRef *Event)
+void CreateHotkeyFromCGEvent(CGEventRef Event, hotkey *Hotkey)
 {
-    modifiers Mod = {};
-    CGEventFlags Flags = CGEventGetFlags(*Event);
-    Mod.CmdKey = (Flags & kCGEventFlagMaskCommand) == kCGEventFlagMaskCommand;
-    Mod.AltKey = (Flags & kCGEventFlagMaskAlternate) == kCGEventFlagMaskAlternate;
-    Mod.CtrlKey = (Flags & kCGEventFlagMaskControl) == kCGEventFlagMaskControl;
-    Mod.ShiftKey = (Flags & kCGEventFlagMaskShift) == kCGEventFlagMaskShift;
-    CGKeyCode Keycode = (CGKeyCode)CGEventGetIntegerValueField(*Event, kCGKeyboardEventKeycode);
+    CGEventFlags Flags = CGEventGetFlags(Event);
+    Hotkey->Mod.CmdKey = (Flags & kCGEventFlagMaskCommand) == kCGEventFlagMaskCommand;
+    Hotkey->Mod.AltKey = (Flags & kCGEventFlagMaskAlternate) == kCGEventFlagMaskAlternate;
+    Hotkey->Mod.CtrlKey = (Flags & kCGEventFlagMaskControl) == kCGEventFlagMaskControl;
+    Hotkey->Mod.ShiftKey = (Flags & kCGEventFlagMaskShift) == kCGEventFlagMaskShift;
+    Hotkey->Key = (CGKeyCode)CGEventGetIntegerValueField(Event, kCGKeyboardEventKeycode);
+}
 
-    if(KWMHotkeys.Prefix.Enabled && KwmIsPrefixKey(&KWMHotkeys.Prefix.Key, &Mod, Keycode))
+void *KwmMainHotkeyTrigger(void *HotkeyPtr)
+{
+    while(true)
     {
-        KWMHotkeys.Prefix.Active = true;
-        KWMHotkeys.Prefix.Time = std::chrono::steady_clock::now();
-        if(PrefixBorder.Enabled)
-            UpdateBorder("focused");
+        while(!KWMHotkeys.Queue.empty())
+        {
+            hotkey Hotkey = KWMHotkeys.Queue.front();
+            KWMHotkeys.Queue.pop();
 
-        return true;
+            if(ShouldKeyBeProcessed(&Hotkey))
+                KwmExecuteHotkey(&Hotkey);
+        }
+
+        usleep(10000);
     }
 
-    return KwmExecuteHotkey(Mod, Keycode);
+    return NULL;
 }
 
 bool KwmIsPrefixKey(hotkey *PrefixKey, modifiers *Mod, CGKeyCode Keycode)
@@ -95,38 +101,38 @@ bool IsHotkeyStateReqFulfilled(hotkey *Hotkey)
     return true;
 }
 
-bool KwmExecuteHotkey(modifiers Mod, CGKeyCode Keycode)
+bool ShouldKeyBeProcessed(hotkey *Hotkey)
 {
-    hotkey Hotkey = {};
-    if(HotkeyExists(Mod, Keycode, &Hotkey))
+    if(KWMHotkeys.Prefix.Enabled &&
+       KwmIsPrefixKey(&KWMHotkeys.Prefix.Key, &Hotkey->Mod, Hotkey->Key))
     {
-        if(KWMHotkeys.Prefix.Enabled)
-        {
-            CheckPrefixTimeout();
-            if((Hotkey.Prefixed || KWMHotkeys.Prefix.Global) &&
-                !KWMHotkeys.Prefix.Active)
-                    return false;
+        KWMHotkeys.Prefix.Active = true;
+        KWMHotkeys.Prefix.Time = std::chrono::steady_clock::now();
+        if(PrefixBorder.Enabled)
+            UpdateBorder("focused");
 
-            if((Hotkey.Prefixed || KWMHotkeys.Prefix.Global) &&
-                KWMHotkeys.Prefix.Active)
-                    KWMHotkeys.Prefix.Time = std::chrono::steady_clock::now();
-        }
-
-        if(IsHotkeyStateReqFulfilled(&Hotkey))
-        {
-            if(Hotkey.Command.empty())
-                return true;
-
-            if(Hotkey.IsSystemCommand)
-                KwmExecuteThreadedSystemCommand(Hotkey.Command);
-            else
-                KwmInterpretCommand(Hotkey.Command, 0);
-
-            return true;
-        }
+        return false;
     }
 
-    return false;
+    if(!IsHotkeyStateReqFulfilled(Hotkey))
+        return false;
+
+    return true;
+}
+
+void KwmExecuteHotkey(hotkey *Hotkey)
+{
+    DEBUG("KwmExecuteHotkey")
+    if(Hotkey->Command.empty())
+        return;
+
+    if(Hotkey->IsSystemCommand)
+        KwmExecuteThreadedSystemCommand(Hotkey->Command);
+    else
+        KwmInterpretCommand(Hotkey->Command, 0);
+
+    if((Hotkey->Prefixed || KWMHotkeys.Prefix.Global) && KWMHotkeys.Prefix.Active)
+        KWMHotkeys.Prefix.Time = std::chrono::steady_clock::now();
 }
 
 bool HotkeyExists(modifiers Mod, CGKeyCode Keycode, hotkey *Hotkey)
@@ -142,8 +148,19 @@ bool HotkeyExists(modifiers Mod, CGKeyCode Keycode, hotkey *Hotkey)
             if(Hotkey)
                 *Hotkey = KWMHotkeys.List[HotkeyIndex];
 
-            return true;
+            if((Hotkey->Prefixed || KWMHotkeys.Prefix.Global) && KWMHotkeys.Prefix.Active)
+                return true;
+            else if(!Hotkey->Prefixed && !KWMHotkeys.Prefix.Global)
+                return true;
         }
+    }
+
+    if(KwmIsPrefixKey(&KWMHotkeys.Prefix.Key, &TempHotkey.Mod, TempHotkey.Key))
+    {
+        if(Hotkey)
+            *Hotkey = KWMHotkeys.Prefix.Key;
+
+        return true;
     }
 
     return false;

--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -145,17 +145,16 @@ bool HotkeyExists(modifiers Mod, CGKeyCode Keycode, hotkey *Hotkey)
 
     for(std::size_t HotkeyIndex = 0; HotkeyIndex < KWMHotkeys.List.size(); ++HotkeyIndex)
     {
-        if(HotkeysAreEqual(&KWMHotkeys.List[HotkeyIndex], &TempHotkey))
+        hotkey *CheckHotkey = &KWMHotkeys.List[HotkeyIndex];
+        if(HotkeysAreEqual(CheckHotkey, &TempHotkey))
         {
             if(Hotkey)
-            {
-                *Hotkey = KWMHotkeys.List[HotkeyIndex];
+                *Hotkey = *CheckHotkey;
 
-                if((Hotkey->Prefixed || KWMHotkeys.Prefix.Global) && KWMHotkeys.Prefix.Active)
-                    return true;
-                else if(!Hotkey->Prefixed && !KWMHotkeys.Prefix.Global)
-                    return true;
-            }
+            if((CheckHotkey->Prefixed || KWMHotkeys.Prefix.Global) && KWMHotkeys.Prefix.Active)
+                return true;
+            else if(!CheckHotkey->Prefixed && !KWMHotkeys.Prefix.Global)
+                return true;
         }
     }
 

--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -148,12 +148,14 @@ bool HotkeyExists(modifiers Mod, CGKeyCode Keycode, hotkey *Hotkey)
         if(HotkeysAreEqual(&KWMHotkeys.List[HotkeyIndex], &TempHotkey))
         {
             if(Hotkey)
+            {
                 *Hotkey = KWMHotkeys.List[HotkeyIndex];
 
-            if((Hotkey->Prefixed || KWMHotkeys.Prefix.Global) && KWMHotkeys.Prefix.Active)
-                return true;
-            else if(!Hotkey->Prefixed && !KWMHotkeys.Prefix.Global)
-                return true;
+                if((Hotkey->Prefixed || KWMHotkeys.Prefix.Global) && KWMHotkeys.Prefix.Active)
+                    return true;
+                else if(!Hotkey->Prefixed && !KWMHotkeys.Prefix.Global)
+                    return true;
+            }
         }
     }
 

--- a/kwm/keys.h
+++ b/kwm/keys.h
@@ -9,11 +9,13 @@ bool HotkeyExists(modifiers Mod, CGKeyCode Keycode, hotkey *Hotkey);
 void DetermineHotkeyState(hotkey *Hotkey, std::string &Command);
 bool IsHotkeyStateReqFulfilled(hotkey *Hotkey);
 
+bool ShouldKeyBeProcessed(hotkey *Hotkey);
+void CreateHotkeyFromCGEvent(CGEventRef Event, hotkey *Hotkey);
 bool KwmParseHotkey(std::string KeySym, std::string Command, hotkey *Hotkey);
 void KwmAddHotkey(std::string KeySym, std::string Command);
 void KwmRemoveHotkey(std::string KeySym);
-bool KwmExecuteHotkey(modifiers Mod, CGKeyCode Keycode);
-bool KwmMainHotkeyTrigger(CGEventRef *Event);
+void KwmExecuteHotkey(hotkey *Hotkey);
+void *KwmMainHotkeyTrigger(void *EventPtr);
 void KwmEmitKeystrokes(std::string Text);
 void KwmEmitKeystroke(modifiers Mod, std::string Key);
 void KwmEmitKeystroke(std::string KeySym);

--- a/kwm/kwm.cpp
+++ b/kwm/kwm.cpp
@@ -27,8 +27,6 @@ kwm_callback KWMCallback =  {};
 
 CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef Event, void *Refcon)
 {
-    pthread_mutex_lock(&KWMThread.Lock);
-
     switch(Type)
     {
         case kCGEventTapDisabledByTimeout:
@@ -46,7 +44,6 @@ CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef E
                 if(HotkeyExists(Eventkey.Mod, Eventkey.Key, &Hotkey))
                 {
                     KWMHotkeys.Queue.push(Hotkey);
-                    pthread_mutex_unlock(&KWMThread.Lock);
                     return NULL;
                 }
             }
@@ -56,7 +53,6 @@ CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef E
             {
                 CGEventSetIntegerValueField(Event, kCGKeyboardEventAutorepeat, 0);
                 CGEventPostToPSN(&KWMFocus.PSN, Event);
-                pthread_mutex_unlock(&KWMThread.Lock);
                 return NULL;
             }
         } break;
@@ -67,22 +63,22 @@ CGEventRef CGEventCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef E
             {
                 CGEventSetIntegerValueField(Event, kCGKeyboardEventAutorepeat, 0);
                 CGEventPostToPSN(&KWMFocus.PSN, Event);
-                pthread_mutex_unlock(&KWMThread.Lock);
                 return NULL;
             }
         } break;
         case kCGEventMouseMoved:
         {
+            pthread_mutex_lock(&KWMThread.Lock);
             UpdateActiveScreen();
 
             if(KWMMode.Focus != FocusModeDisabled &&
                KWMMode.Focus != FocusModeStandby &&
                !IsActiveSpaceFloating())
                 FocusWindowBelowCursor();
+            pthread_mutex_unlock(&KWMThread.Lock);
         } break;
     }
 
-    pthread_mutex_unlock(&KWMThread.Lock);
     return Event;
 }
 

--- a/kwm/notifications.cpp
+++ b/kwm/notifications.cpp
@@ -1,4 +1,6 @@
 #include "notifications.h"
+#include "display.h"
+#include "space.h"
 #include "window.h"
 #include "border.h"
 
@@ -22,6 +24,15 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
         {
             DEBUG("Element: " << GetWindowTitle(Element))
             SetKwmFocus(Element);
+            screen_info *Screen = GetDisplayOfWindow(KWMFocus.Window);
+            if(Screen && KWMScreen.Current != Screen)
+            {
+                KWMScreen.PrevSpace = KWMScreen.Current->ActiveSpace;
+                KWMScreen.Current = Screen;
+                KWMScreen.Current->ActiveSpace = GetActiveSpaceOfDisplay(KWMScreen.Current);
+                ShouldActiveSpaceBeManaged();
+                MoveCursorToCenterOfFocusedWindow();
+            }
         }
     }
     else if(CFEqual(Notification, kAXWindowResizedNotification) ||

--- a/kwm/notifications.cpp
+++ b/kwm/notifications.cpp
@@ -16,6 +16,14 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
     window_info *Window = KWMFocus.Window;
     if(Window && CFEqual(Notification, kAXTitleChangedNotification))
         Window->Name = GetWindowTitle(Element);
+    else if(CFEqual(Notification, kAXFocusedWindowChangedNotification))
+    {
+        if(!Window || Window->WID != GetWindowIDFromRef(Element))
+        {
+            DEBUG("Element: " << GetWindowTitle(Element))
+            SetKwmFocus(Element);
+        }
+    }
     else if(CFEqual(Notification, kAXWindowResizedNotification) ||
             CFEqual(Notification, kAXWindowMovedNotification) ||
             CFEqual(Notification, kAXWindowMiniaturizedNotification))
@@ -37,6 +45,7 @@ void DestroyApplicationNotifications()
     AXObserverRemoveNotification(KWMFocus.Observer, KWMFocus.Application, kAXWindowMovedNotification);
     AXObserverRemoveNotification(KWMFocus.Observer, KWMFocus.Application, kAXWindowResizedNotification);
     AXObserverRemoveNotification(KWMFocus.Observer, KWMFocus.Application, kAXTitleChangedNotification);
+    AXObserverRemoveNotification(KWMFocus.Observer, KWMFocus.Application, kAXFocusedWindowChangedNotification);
     CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(KWMFocus.Observer), kCFRunLoopDefaultMode);
 
     CFRelease(KWMFocus.Observer);
@@ -62,6 +71,7 @@ void CreateApplicationNotifications()
             AXObserverAddNotification(KWMFocus.Observer, KWMFocus.Application, kAXWindowMovedNotification, NULL);
             AXObserverAddNotification(KWMFocus.Observer, KWMFocus.Application, kAXWindowResizedNotification, NULL);
             AXObserverAddNotification(KWMFocus.Observer, KWMFocus.Application, kAXTitleChangedNotification, NULL);
+            AXObserverAddNotification(KWMFocus.Observer, KWMFocus.Application, kAXFocusedWindowChangedNotification, NULL);
             CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(KWMFocus.Observer), kCFRunLoopDefaultMode);
         }
     }

--- a/kwm/notifications.cpp
+++ b/kwm/notifications.cpp
@@ -28,7 +28,7 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
             if(OSXWindow && Screen)
             {
                 screen_info *ScreenOfWindow = GetDisplayOfWindow(Window);
-                if(ScreenOfWindow && Window)
+                if(ScreenOfWindow && Window && ScreenOfWindow != Screen)
                 {
                     space_info *SpaceOfWindow = GetActiveSpaceOfScreen(ScreenOfWindow);
                     if(SpaceOfWindow->Mode == SpaceModeBSP)
@@ -37,10 +37,12 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
                         RemoveWindowFromMonocleTree(ScreenOfWindow, Window->WID, false);
 
                     SpaceOfWindow->FocusedWindowID = 0;
+                    GiveFocusToScreen(Screen->ID, NULL, false, false);
                 }
 
-                GiveFocusToScreen(Screen->ID, NULL, false, false);
                 SetKwmFocus(Element);
+                if(Screen == ScreenOfWindow)
+                    KWMFocus.InsertionPoint = KWMFocus.Cache;
             }
         }
     }

--- a/kwm/notifications.cpp
+++ b/kwm/notifications.cpp
@@ -23,15 +23,12 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
         if(!Window || Window->WID != GetWindowIDFromRef(Element))
         {
             DEBUG("Element: " << GetWindowTitle(Element))
-            SetKwmFocus(Element);
-            screen_info *Screen = GetDisplayOfWindow(KWMFocus.Window);
-            if(Screen && KWMScreen.Current != Screen)
+            window_info *OSXWindow = GetWindowByID(GetWindowIDFromRef(Element));
+            screen_info *Screen = GetDisplayOfWindow(OSXWindow);
+            if(Window && Screen)
             {
-                KWMScreen.PrevSpace = KWMScreen.Current->ActiveSpace;
-                KWMScreen.Current = Screen;
-                KWMScreen.Current->ActiveSpace = GetActiveSpaceOfDisplay(KWMScreen.Current);
-                ShouldActiveSpaceBeManaged();
-                MoveCursorToCenterOfFocusedWindow();
+                GiveFocusToScreen(Screen->ID, NULL, false, false);
+                SetKwmFocus(Element);
             }
         }
     }

--- a/kwm/notifications.cpp
+++ b/kwm/notifications.cpp
@@ -24,11 +24,15 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
         {
             DEBUG("Element: " << GetWindowTitle(Element))
             window_info *OSXWindow = GetWindowByID(GetWindowIDFromRef(Element));
-            screen_info *Screen = GetDisplayOfWindow(OSXWindow);
-            if(OSXWindow && Screen)
+            screen_info *OSXScreen = GetDisplayOfWindow(OSXWindow);
+            if(OSXWindow && OSXScreen)
             {
                 screen_info *ScreenOfWindow = GetDisplayOfWindow(Window);
-                if(ScreenOfWindow && Window && ScreenOfWindow != Screen)
+                UpdateActiveWindowList(ScreenOfWindow);
+
+                if(ScreenOfWindow && Window &&
+                   GetWindowByID(Window->WID) == NULL &&
+                   OSXScreen != ScreenOfWindow)
                 {
                     space_info *SpaceOfWindow = GetActiveSpaceOfScreen(ScreenOfWindow);
                     if(SpaceOfWindow->Mode == SpaceModeBSP)
@@ -37,11 +41,11 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
                         RemoveWindowFromMonocleTree(ScreenOfWindow, Window->WID, false);
 
                     SpaceOfWindow->FocusedWindowID = 0;
-                    GiveFocusToScreen(Screen->ID, NULL, false, false);
                 }
 
+                GiveFocusToScreen(OSXScreen->ID, NULL, false, false);
                 SetKwmFocus(Element);
-                if(Screen == ScreenOfWindow)
+                if(OSXScreen == ScreenOfWindow)
                     KWMFocus.InsertionPoint = KWMFocus.Cache;
             }
         }

--- a/kwm/notifications.cpp
+++ b/kwm/notifications.cpp
@@ -25,8 +25,20 @@ void FocusedAXObserverCallback(AXObserverRef Observer, AXUIElementRef Element, C
             DEBUG("Element: " << GetWindowTitle(Element))
             window_info *OSXWindow = GetWindowByID(GetWindowIDFromRef(Element));
             screen_info *Screen = GetDisplayOfWindow(OSXWindow);
-            if(Window && Screen)
+            if(OSXWindow && Screen)
             {
+                screen_info *ScreenOfWindow = GetDisplayOfWindow(Window);
+                if(ScreenOfWindow && Window)
+                {
+                    space_info *SpaceOfWindow = GetActiveSpaceOfScreen(ScreenOfWindow);
+                    if(SpaceOfWindow->Mode == SpaceModeBSP)
+                        RemoveWindowFromBSPTree(ScreenOfWindow, Window->WID, false, false);
+                    else if(SpaceOfWindow->Mode == SpaceModeMonocle)
+                        RemoveWindowFromMonocleTree(ScreenOfWindow, Window->WID, false);
+
+                    SpaceOfWindow->FocusedWindowID = 0;
+                }
+
                 GiveFocusToScreen(Screen->ID, NULL, false, false);
                 SetKwmFocus(Element);
             }

--- a/kwm/types.h
+++ b/kwm/types.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <vector>
+#include <queue>
 #include <map>
 #include <fstream>
 #include <sstream>
@@ -264,6 +265,7 @@ struct kwm_prefix
 
 struct kwm_hotkeys
 {
+    std::queue<hotkey> Queue;
     std::vector<hotkey> List;
     kwm_prefix Prefix;
     modifiers SpacesKey;
@@ -349,6 +351,7 @@ struct kwm_thread
 {
     pthread_t WindowMonitor;
     pthread_t SystemCommand;
+    pthread_t Hotkey;
     pthread_t Daemon;
     pthread_mutex_t Lock;
 };

--- a/kwm/types.h
+++ b/kwm/types.h
@@ -295,6 +295,7 @@ struct kwm_focus
     window_info *Window;
     window_info Cache;
     window_info NULLWindowInfo;
+    window_info InsertionPoint;
 };
 
 struct kwm_screen

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -1168,7 +1168,9 @@ bool FindClosestWindow(int Degrees, window_info *Target, bool Wrap)
     for(int Index = 0; Index < Windows.size(); ++Index)
     {
         if(!WindowsAreEqual(Match, &Windows[Index]) &&
-           WindowIsInDirection(Match, &Windows[Index], Degrees, Wrap))
+           WindowIsInDirection(Match, &Windows[Index], Degrees, Wrap) &&
+           !IsWindowFloating(Windows[Index].WID, NULL) &&
+           !IsApplicationFloating(&Windows[Index]))
         {
             window_info FocusWindow = Windows[Index];
 

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -1468,12 +1468,12 @@ void SetWindowRefFocus(AXUIElementRef WindowRef)
     GetProcessForPID(KWMFocus.Window->PID, &NewPSN);
     KWMFocus.PSN = NewPSN;
 
+    if(KWMMode.Focus != FocusModeAutofocus && KWMMode.Focus != FocusModeStandby)
+        SetFrontProcessWithOptions(&KWMFocus.PSN, kSetFrontProcessFrontWindowOnly);
+
     AXUIElementSetAttributeValue(WindowRef, kAXMainAttribute, kCFBooleanTrue);
     AXUIElementSetAttributeValue(WindowRef, kAXFocusedAttribute, kCFBooleanTrue);
     AXUIElementPerformAction(WindowRef, kAXRaiseAction);
-
-    if(KWMMode.Focus != FocusModeAutofocus && KWMMode.Focus != FocusModeStandby)
-        SetFrontProcessWithOptions(&KWMFocus.PSN, kSetFrontProcessFrontWindowOnly);
 
     if(!IsActiveSpaceFloating())
     {

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -512,16 +512,17 @@ void AddWindowToBSPTree(screen_info *Screen, int WindowID)
     tree_node *CurrentNode = NULL;
 
     DEBUG("AddWindowToBSPTree() Create pair of leafs")
-    bool UseFocusedContainer = KWMFocus.Window &&
-                               IsWindowOnActiveSpace(KWMFocus.Window->WID) &&
-                               KWMFocus.Window->WID != WindowID;
+    window_info *InsertionPoint = !WindowsAreEqual(&KWMFocus.InsertionPoint, &KWMFocus.NULLWindowInfo) ? &KWMFocus.InsertionPoint : NULL;
+    bool UseFocusedContainer = InsertionPoint &&
+                               IsWindowOnActiveSpace(InsertionPoint->WID) &&
+                               InsertionPoint->WID != WindowID;
 
     bool DoNotUseMarkedContainer = IsWindowFloating(KWMScreen.MarkedWindow, NULL) ||
                                    (KWMScreen.MarkedWindow == WindowID);
 
     if(KWMScreen.MarkedWindow == -1 && UseFocusedContainer)
     {
-        CurrentNode = GetTreeNodeFromWindowIDOrLinkNode(RootNode, KWMFocus.Window->WID);
+        CurrentNode = GetTreeNodeFromWindowIDOrLinkNode(RootNode, InsertionPoint->WID);
     }
     else if(DoNotUseMarkedContainer || (KWMScreen.MarkedWindow == -1 && !UseFocusedContainer))
     {
@@ -1459,6 +1460,8 @@ void SetWindowRefFocus(AXUIElementRef WindowRef)
     }
 
     KWMFocus.Window = &KWMFocus.Cache;
+    KWMFocus.InsertionPoint = KWMFocus.Cache;
+
     ProcessSerialNumber NewPSN;
     GetProcessForPID(KWMFocus.Window->PID, &NewPSN);
     KWMFocus.PSN = NewPSN;

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -83,11 +83,7 @@ bool FilterWindowList(screen_info *Screen)
         /* Note(koekeishiya):
          * Mission-Control mode is on and so we do not try to tile windows */
         if(Window->Owner == "Dock" && Window->Name == "")
-        {
-                ClearFocusedWindow();
-                ClearMarkedWindow();
                 return false;
-        }
 
         if(Window->Layer == 0)
         {

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -1357,7 +1357,7 @@ void FocusWindowByID(int WindowID)
             tree_node *Root = Space->RootNode;
             tree_node *Node = GetTreeNodeFromWindowID(Root, WindowID);
             if(Node)
-                GiveFocusToScreen(Screen->ID, Node, false);
+                GiveFocusToScreen(Screen->ID, Node, false, true);
         }
     }
 }

--- a/kwm/window.h
+++ b/kwm/window.h
@@ -19,6 +19,7 @@ bool WindowsAreEqual(window_info *Window, window_info *Match);
 
 void ClearFocusedWindow();
 int GetFocusedWindowID();
+bool GetWindowFocusedByOSX(AXUIElementRef *WindowRef);
 bool FocusWindowOfOSX();
 void FocusWindowBelowCursor();
 
@@ -65,6 +66,7 @@ void MarkWindowContainer(window_info *Window);
 void MarkFocusedWindowContainer();
 
 void SetWindowRefFocus(AXUIElementRef WindowRef);
+void SetKwmFocus(AXUIElementRef WindowRef);
 void SetWindowFocus(window_info *Window);
 void SetWindowFocusByNode(tree_node *Node);
 void SetWindowFocusByNode(link_node *Link);
@@ -82,7 +84,7 @@ void ResizeWindowToContainerSize(window_info *Window);
 void ResizeWindowToContainerSize();
 
 CGPoint GetCursorPos();
-inline int GetWindowIDFromRef(AXUIElementRef WindowRef);
+int GetWindowIDFromRef(AXUIElementRef WindowRef);
 window_info GetWindowByRef(AXUIElementRef WindowRef);
 window_info *GetWindowByID(int WindowID);
 std::string GetUTF8String(CFStringRef Temp);

--- a/kwm/workspace.mm
+++ b/kwm/workspace.mm
@@ -63,6 +63,7 @@ int GetActiveSpaceOfDisplay(screen_info *Screen);
     if(ProcessID != -1)
     {
         window_info *Window = KWMFocus.Window;
+        screen_info *ScreenOfWindow = GetDisplayOfWindow(Window);
         if((Window && Window->PID != ProcessID) || !Window)
         {
             AXUIElementRef OSXWindowRef;
@@ -72,8 +73,12 @@ int GetActiveSpaceOfDisplay(screen_info *Screen);
                 screen_info *Screen = GetDisplayOfWindow(OSXWindow);
                 if(Window && Screen)
                 {
-                    GiveFocusToScreen(Screen->ID, NULL, false, false);
+                    if(ScreenOfWindow && ScreenOfWindow != Screen)
+                        GiveFocusToScreen(Screen->ID, NULL, false, false);
+
                     SetKwmFocus(OSXWindowRef);
+                    if(Screen == ScreenOfWindow)
+                        KWMFocus.InsertionPoint = KWMFocus.Cache;
                 }
             }
         }

--- a/kwm/workspace.mm
+++ b/kwm/workspace.mm
@@ -64,15 +64,14 @@ int GetActiveSpaceOfDisplay(screen_info *Screen);
             if(GetWindowFocusedByOSX(&OSXWindowRef))
             {
                 SetKwmFocus(OSXWindowRef);
-                MoveCursorToCenterOfFocusedWindow();
-
                 screen_info *Screen = GetDisplayOfWindow(KWMFocus.Window);
-                if(Screen)
+                if(Screen && KWMScreen.Current != Screen)
                 {
                     KWMScreen.PrevSpace = KWMScreen.Current->ActiveSpace;
                     KWMScreen.Current = Screen;
                     KWMScreen.Current->ActiveSpace = GetActiveSpaceOfDisplay(KWMScreen.Current);
                     ShouldActiveSpaceBeManaged();
+                    MoveCursorToCenterOfFocusedWindow();
                 }
             }
         }

--- a/kwm/workspace.mm
+++ b/kwm/workspace.mm
@@ -2,23 +2,19 @@
 #import "types.h"
 #include "notifications.h"
 
-extern bool FilterWindowList(screen_info *Screen);
-extern void UpdateActiveWindowList(screen_info *Screen);
-extern void MoveCursorToCenterOfFocusedWindow();
 extern void UpdateActiveSpace();
 extern screen_info *GetDisplayOfWindow(window_info *Window);
 extern bool GetWindowFocusedByOSX(AXUIElementRef *WindowRef);
 extern void SetKwmFocus(AXUIElementRef WindowRef);
-extern bool ShouldActiveSpaceBeManaged();
 extern void GiveFocusToScreen(unsigned int ScreenIndex, tree_node *Focus, bool Mouse, bool UpdateFocus);
 extern window_info *GetWindowByID(int WindowID);
 extern int GetWindowIDFromRef(AXUIElementRef WindowRef);
+extern space_info *GetActiveSpaceOfScreen(screen_info *Screen);
+extern tree_node *GetTreeNodeFromWindowIDOrLinkNode(tree_node *RootNode, int WindowID);
 
 extern kwm_focus KWMFocus;
 extern kwm_screen KWMScreen;
 extern kwm_thread KWMThread;
-
-int GetActiveSpaceOfDisplay(screen_info *Screen);
 
 @interface MDWorkspaceWatcher : NSObject {
 }
@@ -73,12 +69,17 @@ int GetActiveSpaceOfDisplay(screen_info *Screen);
                 screen_info *Screen = GetDisplayOfWindow(OSXWindow);
                 if(Window && Screen)
                 {
-                    if(ScreenOfWindow && ScreenOfWindow != Screen)
-                        GiveFocusToScreen(Screen->ID, NULL, false, false);
+                    space_info *Space = GetActiveSpaceOfScreen(Screen);
+                    tree_node *TreeNode = GetTreeNodeFromWindowIDOrLinkNode(Space->RootNode, OSXWindow->WID);
+                    if(TreeNode)
+                    {
+                        if(ScreenOfWindow && ScreenOfWindow != Screen)
+                            GiveFocusToScreen(Screen->ID, NULL, false, false);
 
-                    SetKwmFocus(OSXWindowRef);
-                    if(Screen == ScreenOfWindow)
-                        KWMFocus.InsertionPoint = KWMFocus.Cache;
+                        SetKwmFocus(OSXWindowRef);
+                        if(Screen == ScreenOfWindow)
+                            KWMFocus.InsertionPoint = KWMFocus.Cache;
+                    }
                 }
             }
         }

--- a/kwm/workspace.mm
+++ b/kwm/workspace.mm
@@ -66,18 +66,16 @@ extern kwm_thread KWMThread;
             if(GetWindowFocusedByOSX(&OSXWindowRef))
             {
                 window_info *OSXWindow = GetWindowByID(GetWindowIDFromRef(OSXWindowRef));
-                screen_info *Screen = GetDisplayOfWindow(OSXWindow);
-                if(Window && Screen)
+                screen_info *OSXScreen = GetDisplayOfWindow(OSXWindow);
+                if(OSXWindow && OSXScreen)
                 {
-                    space_info *Space = GetActiveSpaceOfScreen(Screen);
-                    tree_node *TreeNode = GetTreeNodeFromWindowIDOrLinkNode(Space->RootNode, OSXWindow->WID);
+                    space_info *OSXSpace = GetActiveSpaceOfScreen(OSXScreen);
+                    tree_node *TreeNode = GetTreeNodeFromWindowIDOrLinkNode(OSXSpace->RootNode, OSXWindow->WID);
                     if(TreeNode)
                     {
-                        if(ScreenOfWindow && ScreenOfWindow != Screen)
-                            GiveFocusToScreen(Screen->ID, NULL, false, false);
-
+                        GiveFocusToScreen(OSXScreen->ID, NULL, false, false);
                         SetKwmFocus(OSXWindowRef);
-                        if(Screen == ScreenOfWindow)
+                        if(OSXScreen == ScreenOfWindow)
                             KWMFocus.InsertionPoint = KWMFocus.Cache;
                     }
                 }

--- a/kwm/workspace.mm
+++ b/kwm/workspace.mm
@@ -2,12 +2,17 @@
 #import "types.h"
 #include "notifications.h"
 
+extern bool FilterWindowList(screen_info *Screen);
+extern void UpdateActiveWindowList(screen_info *Screen);
 extern void MoveCursorToCenterOfFocusedWindow();
 extern void UpdateActiveSpace();
 extern screen_info *GetDisplayOfWindow(window_info *Window);
 extern bool GetWindowFocusedByOSX(AXUIElementRef *WindowRef);
 extern void SetKwmFocus(AXUIElementRef WindowRef);
 extern bool ShouldActiveSpaceBeManaged();
+extern void GiveFocusToScreen(unsigned int ScreenIndex, tree_node *Focus, bool Mouse, bool UpdateFocus);
+extern window_info *GetWindowByID(int WindowID);
+extern int GetWindowIDFromRef(AXUIElementRef WindowRef);
 
 extern kwm_focus KWMFocus;
 extern kwm_screen KWMScreen;
@@ -63,15 +68,12 @@ int GetActiveSpaceOfDisplay(screen_info *Screen);
             AXUIElementRef OSXWindowRef;
             if(GetWindowFocusedByOSX(&OSXWindowRef))
             {
-                SetKwmFocus(OSXWindowRef);
-                screen_info *Screen = GetDisplayOfWindow(KWMFocus.Window);
-                if(Screen && KWMScreen.Current != Screen)
+                window_info *OSXWindow = GetWindowByID(GetWindowIDFromRef(OSXWindowRef));
+                screen_info *Screen = GetDisplayOfWindow(OSXWindow);
+                if(Window && Screen)
                 {
-                    KWMScreen.PrevSpace = KWMScreen.Current->ActiveSpace;
-                    KWMScreen.Current = Screen;
-                    KWMScreen.Current->ActiveSpace = GetActiveSpaceOfDisplay(KWMScreen.Current);
-                    ShouldActiveSpaceBeManaged();
-                    MoveCursorToCenterOfFocusedWindow();
+                    GiveFocusToScreen(Screen->ID, NULL, false, false);
+                    SetKwmFocus(OSXWindowRef);
                 }
             }
         }


### PR DESCRIPTION
Kwm should now automatically update its focus when the active application or window is changed by OSX.

The hotkeys are now polled from a queue on its own thread. This should prevent Kwm from causing delays in the OSX Event Dispatch thread.