### PR TITLE
Destroy notifications for unmanaged spaces

### DIFF
--- a/kwm/space.cpp
+++ b/kwm/space.cpp
@@ -322,6 +322,7 @@ void UpdateActiveSpace()
     {
         ClearFocusedWindow();
         ClearMarkedWindow();
+        DestroyApplicationNotifications();
     }
 
     KWMScreen.Transitioning = false;


### PR DESCRIPTION
I like your change on cleaning up in UpdateActiveSpace() and by destroying the notifications we shouldn't get any more conflict.