### PR TITLE
kwm-overlay: Make overlay window mask borderless

### DIFF
--- a/kwm-overlay/kwm-overlay.swift
+++ b/kwm-overlay/kwm-overlay.swift
@@ -193,12 +193,7 @@ class OverlayController: NSObject, NSApplicationDelegate
     {
         window.opaque = false
         window.backgroundColor = NSColor.clearColor()
-        if #available(OSX 10.10, *) {
-            window.titleVisibility = NSWindowTitleVisibility.Hidden
-            window.titlebarAppearsTransparent = true
-            window.styleMask |= NSFullSizeContentViewWindowMask
-        }
-
+        window.styleMask = NSBorderlessWindowMask
         window.ignoresMouseEvents = true
         window.level = Int(CGWindowLevelForKey(.FloatingWindowLevelKey))
         window.hasShadow = false


### PR DESCRIPTION
When using border radius values lower than OS X window own border radius, the
outer corner would get cut off. By using Borderless status mask, OS X
doesn't round the corners for us.

The issue is really noticeable when using a radius value like 0.