### PR TITLE
Handle multiple cmds to kwm-overlay

### DIFF
--- a/kwm-overlay/kwm-overlay.swift
+++ b/kwm-overlay/kwm-overlay.swift
@@ -200,7 +200,6 @@ class OverlayController: NSObject, NSApplicationDelegate
         window.collectionBehavior = NSWindowCollectionBehavior.CanJoinAllSpaces
         window.makeKeyAndOrderFront(self)
         self.listenToStdIn()
-
     }
 
     func listenToStdIn() -> NSObjectProtocol
@@ -214,17 +213,18 @@ class OverlayController: NSObject, NSApplicationDelegate
             let data = outHandle.availableData
             if (data.length > 0) {
                 if let str = NSString(data: data, encoding: NSUTF8StringEncoding) as String? {
-                    let trimmedString = trim(str);
+                    str.enumerateLines { (line, stop) -> () in
+                        let trimmedString = trim(line);
 
-                    if (trimmedString == "clear") {
-                        self.window.contentView = nil
-                    } else if (trimmedString == "quit") {
-                        exit(0)
-                    } else {
-                        let args = trimmedString.componentsSeparatedByString(" ")
-                        self.showOverlayView(args)
+                        if (trimmedString == "clear") {
+                            self.window.contentView = nil
+                        } else if (trimmedString == "quit") {
+                            exit(0)
+                        } else {
+                            let args = trimmedString.componentsSeparatedByString(" ")
+                                self.showOverlayView(args)
+                        }
                     }
-
                     outHandle.waitForDataInBackgroundAndNotify()
                 } else {
                     NSNotificationCenter.defaultCenter().removeObserver(stdListen)

--- a/kwm/border.h
+++ b/kwm/border.h
@@ -29,7 +29,7 @@ CloseBorder(kwm_border *Border)
 {
     if(Border->Handle)
     {
-        static std::string Terminate = "quit";
+        static std::string Terminate = "quit\n";
         fwrite(Terminate.c_str(), Terminate.size(), 1, Border->Handle);
         fflush(Border->Handle);
         pclose(Border->Handle);
@@ -42,7 +42,7 @@ ClearBorder(kwm_border *Border)
 {
     if(Border->Handle)
     {
-        static std::string Command = "clear";
+        static std::string Command = "clear\n";
         fwrite(Command.c_str(), Command.size(), 1, Border->Handle);
         fflush(Border->Handle);
     }
@@ -65,10 +65,11 @@ RefreshBorder(kwm_border *Border, int WindowID)
                               " s:" + std::to_string(Border->Width);
 
         Command += Border->Radius != -1 ? " rad:" + std::to_string(Border->Radius) : "";
+        Command += "\n";
         if(WindowPos.x == 0 && WindowPos.y == 0 &&
            WindowSize.width == KWMScreen.Current->Width &&
            WindowSize.height == KWMScreen.Current->Height)
-            Command = "clear";
+            Command = "clear\n";
 
         fwrite(Command.c_str(), Command.size(), 1, Border->Handle);
         fflush(Border->Handle);

--- a/kwm/kwm.cpp
+++ b/kwm/kwm.cpp
@@ -309,6 +309,7 @@ void KwmInit()
 
     pthread_create(&KWMThread.WindowMonitor, NULL, &KwmWindowMonitor, NULL);
     pthread_create(&KWMThread.Hotkey, NULL, &KwmMainHotkeyTrigger, NULL);
+    FocusWindowOfOSX();
 }
 
 bool CheckPrivileges()


### PR DESCRIPTION
Should fix https://github.com/koekeishiya/kwm/issues/318, more context is available there.

It's marked WIP because I'm not sure about just calling `FocusOSXWindow` and if that is even the most appropriate place.