### PR TITLE
Don't move cursor if it's already over focused window

### DIFF
--- a/kwm/cursor.cpp
+++ b/kwm/cursor.cpp
@@ -31,21 +31,32 @@ IsWindowBelowCursor(ax_window *Window)
     return false;
 }
 
-void MoveCursorToCenterOfWindow(ax_window *Window)
+void MoveCursorToWindow(ax_window *Window)
 {
-    if(KWMSettings.UseMouseFollowsFocus)
+    MoveCursorToWindow(Window, false);
+}
+
+void MoveCursorToWindow(ax_window *Window, bool Recenter)
+{
+    if((KWMSettings.UseMouseFollowsFocus) &&
+       (!IsWindowBelowCursor(Window) || Recenter))
     {
         CGWarpMouseCursorPosition(CGPointMake(Window->Position.x + Window->Size.width / 2,
                                               Window->Position.y + Window->Size.height / 2));
     }
 }
 
-void MoveCursorToCenterOfFocusedWindow()
+void MoveCursorToFocusedWindow()
+{
+    MoveCursorToFocusedWindow(false);
+}
+
+void MoveCursorToFocusedWindow(bool Recenter)
 {
     if(KWMSettings.UseMouseFollowsFocus &&
        FocusedApplication &&
        FocusedApplication->Focus)
-        MoveCursorToCenterOfWindow(FocusedApplication->Focus);
+        MoveCursorToWindow(FocusedApplication->Focus, Recenter);
 }
 
 

--- a/kwm/cursor.h
+++ b/kwm/cursor.h
@@ -5,7 +5,9 @@
 #include <Carbon/Carbon.h>
 
 void FocusWindowBelowCursor();
-void MoveCursorToCenterOfWindow(ax_window *Window);
-void MoveCursorToCenterOfFocusedWindow();
+void MoveCursorToFocusedWindow();
+void MoveCursorToWindow(ax_window *Window);
+void MoveCursorToFocusedWindow(bool Recenter);
+void MoveCursorToWindow(ax_window *Window, bool Recenter);
 
 #endif

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -217,7 +217,7 @@ EVENT_CALLBACK(Callback_AXEvent_SpaceChanged)
            (AXLibSpaceHasWindow(FocusedApplication->Focus, Display->Space->ID)))
         {
             DrawFocusedBorder(Display);
-            MoveCursorToCenterOfWindow(FocusedApplication->Focus);
+            MoveCursorToWindow(FocusedApplication->Focus);
             Display->Space->FocusedWindow = FocusedApplication->Focus->ID;
         }
     }
@@ -232,7 +232,7 @@ EVENT_CALLBACK(Callback_AXEvent_SpaceChanged)
         {
             AXLibSetFocusedWindow(Window);
             DrawFocusedBorder(Display);
-            MoveCursorToCenterOfWindow(Window);
+            MoveCursorToWindow(Window);
         }
     }
 
@@ -1150,7 +1150,7 @@ void DetachAndReinsertWindow(unsigned int WindowID, int Degrees)
         ToggleWindowFloating(WindowID, false);
         ClearMarkedWindow();
         ToggleWindowFloating(WindowID, false);
-        MoveCursorToCenterOfFocusedWindow();
+        MoveCursorToFocusedWindow();
     }
     else
     {
@@ -1167,7 +1167,7 @@ void DetachAndReinsertWindow(unsigned int WindowID, int Degrees)
             ax_window *PrevMarkedWindow = MarkedWindow;
             MarkedWindow = ClosestWindow;
             ToggleWindowFloating(WindowID, false);
-            MoveCursorToCenterOfFocusedWindow();
+            MoveCursorToFocusedWindow();
             MarkedWindow = PrevMarkedWindow;
         }
     }
@@ -1191,7 +1191,7 @@ void SwapFocusedWindowWithMarked()
         if(NewFocusNode)
         {
             SwapNodeWindowIDs(TreeNode, NewFocusNode);
-            MoveCursorToCenterOfFocusedWindow();
+            MoveCursorToFocusedWindow();
         }
     }
 
@@ -1231,7 +1231,7 @@ void SwapFocusedWindowWithNearest(int Shift)
             if(ShiftNode)
             {
                 SwapNodeWindowIDs(Link, ShiftNode);
-                MoveCursorToCenterOfWindow(Window);
+                MoveCursorToWindow(Window);
             }
         }
     }
@@ -1250,7 +1250,7 @@ void SwapFocusedWindowWithNearest(int Shift)
             if(NewFocusNode)
             {
                 SwapNodeWindowIDs(TreeNode, NewFocusNode);
-                MoveCursorToCenterOfWindow(Window);
+                MoveCursorToWindow(Window);
             }
         }
     }
@@ -1285,7 +1285,7 @@ void SwapFocusedWindowDirected(int Degrees)
                 SwapNodeWindowIDs(TreeNode, NewFocusNode);
                 Window->Position = AXLibGetWindowPosition(Window->Ref);
                 Window->Size = AXLibGetWindowSize(Window->Ref);
-                MoveCursorToCenterOfWindow(Window);
+                MoveCursorToWindow(Window);
             }
         }
     }
@@ -1437,7 +1437,7 @@ void ShiftWindowFocusDirected(int Degrees)
             FindClosestWindow(Degrees, &ClosestWindow, true)))
         {
             AXLibSetFocusedWindow(ClosestWindow);
-            MoveCursorToCenterOfWindow(ClosestWindow);
+            MoveCursorToWindow(ClosestWindow);
         }
     }
     else if(SpaceInfo->Settings.Mode == SpaceModeMonocle)
@@ -1487,7 +1487,7 @@ void ShiftWindowFocus(int Shift)
             if(FocusNode)
             {
                 SetWindowFocusByNode(FocusNode);
-                MoveCursorToCenterOfFocusedWindow();
+                MoveCursorToFocusedWindow();
             }
         }
     }
@@ -1526,7 +1526,7 @@ void ShiftWindowFocus(int Shift)
             }
 
             SetWindowFocusByNode(FocusNode);
-            MoveCursorToCenterOfFocusedWindow();
+            MoveCursorToFocusedWindow();
         }
     }
 }
@@ -1563,7 +1563,7 @@ void ShiftSubTreeWindowFocus(int Shift)
                     SetWindowFocusByNode(Root);
             }
 
-            MoveCursorToCenterOfFocusedWindow();
+            MoveCursorToFocusedWindow();
         }
         else if(Shift == 1)
         {
@@ -1571,7 +1571,7 @@ void ShiftSubTreeWindowFocus(int Shift)
             if(Root)
             {
                 SetWindowFocusByNode(Root->List);
-                MoveCursorToCenterOfFocusedWindow();
+                MoveCursorToFocusedWindow();
             }
         }
     }


### PR DESCRIPTION
When switching between monocle spaces cursor always jumps to the center of the screen. This is especially annoying for web browsing. I've added a check to move cursor only if it's not already over focused window.

I'm not sure if old behaviour should be preserved for some cases, so I've added an option to 'new' functions to do cursor movement the old way.