### PR TITLE
Check window size position

### DIFF
--- a/kwm/axlib/application.cpp
+++ b/kwm/axlib/application.cpp
@@ -220,8 +220,9 @@ OBSERVER_CALLBACK(AXApplicationCallback)
 
             uint32_t *WindowID = (uint32_t *) malloc(sizeof(uint32_t));
             *WindowID = Window->ID;
-            AXLibConstructEvent(AXEvent_WindowMoved, WindowID, AXLibHasFlags(Window, AXWindow_MoveIntrinsic));
+            bool Intrinsic = AXLibHasFlags(Window, AXWindow_MoveIntrinsic);
             AXLibClearFlags(Window, AXWindow_MoveIntrinsic);
+            AXLibConstructEvent(AXEvent_WindowMoved, WindowID, Intrinsic);
         }
     }
     else if(CFEqual(Notification, kAXWindowResizedNotification))
@@ -235,8 +236,9 @@ OBSERVER_CALLBACK(AXApplicationCallback)
 
             uint32_t *WindowID = (uint32_t *) malloc(sizeof(uint32_t));
             *WindowID = Window->ID;
-            AXLibConstructEvent(AXEvent_WindowResized, WindowID, AXLibHasFlags(Window, AXWindow_SizeIntrinsic));
+            bool Intrinsic = AXLibHasFlags(Window, AXWindow_SizeIntrinsic);
             AXLibClearFlags(Window, AXWindow_SizeIntrinsic);
+            AXLibConstructEvent(AXEvent_WindowResized, WindowID, Intrinsic);
         }
     }
     else if(CFEqual(Notification, kAXTitleChangedNotification))

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -1907,22 +1907,38 @@ void CenterWindowInsideNodeContainer(ax_window *Window, int *Xptr, int *Yptr, in
         Height -= YOff > 0 ? YOff : 0;
 
         AXLibAddFlags(Window, AXWindow_MoveIntrinsic);
-        AXLibSetWindowPosition(Window->Ref, X, Y);
+        if(!AXLibSetWindowPosition(Window->Ref, X, Y))
+            AXLibClearFlags(Window, AXWindow_MoveIntrinsic);
 
         AXLibAddFlags(Window, AXWindow_SizeIntrinsic);
-        AXLibSetWindowSize(Window->Ref, Width, Height);
+        if(!AXLibSetWindowSize(Window->Ref, Width, Height))
+            AXLibClearFlags(Window, AXWindow_SizeIntrinsic);
     }
 }
 
 void SetWindowDimensions(ax_window *Window, int X, int Y, int Width, int Height)
 {
-    AXLibAddFlags(Window, AXWindow_MoveIntrinsic);
-    AXLibSetWindowPosition(Window->Ref, X, Y);
+    bool Changed = false;
+    if((Window->Position.x != X) ||
+       (Window->Position.y != Y))
+    {
+        Changed = true;
+        AXLibAddFlags(Window, AXWindow_MoveIntrinsic);
+        if(!AXLibSetWindowPosition(Window->Ref, X, Y))
+            AXLibClearFlags(Window, AXWindow_MoveIntrinsic);
+    }
 
-    AXLibAddFlags(Window, AXWindow_SizeIntrinsic);
-    AXLibSetWindowSize(Window->Ref, Width, Height);
+    if((Window->Size.width != Width) ||
+       (Window->Size.height != Height))
+    {
+        Changed = true;
+        AXLibAddFlags(Window, AXWindow_SizeIntrinsic);
+        if(!AXLibSetWindowSize(Window->Ref, Width, Height))
+            AXLibClearFlags(Window, AXWindow_SizeIntrinsic);
+    }
 
-    CenterWindowInsideNodeContainer(Window, &X, &Y, &Width, &Height);
+    if(Changed)
+        CenterWindowInsideNodeContainer(Window, &X, &Y, &Width, &Height);
 }
 
 void CenterWindow(ax_display *Display, ax_window *Window)


### PR DESCRIPTION
If multiple events are fired when responding to the first one the window
may already be positioned and resized to the wanted location and size.
Because of that the next events won't trigger a moved/resized
notification keeping Intrinsic flags set indefinitely