### PR TITLE
Add support for Left and Right Control modifiers

### DIFF
--- a/kwm/keys.cpp
+++ b/kwm/keys.cpp
@@ -77,7 +77,18 @@ CompareAltKey(modifier_keys *A, modifier_keys *B)
 internal inline bool
 CompareControlKey(modifier_keys *A, modifier_keys *B)
 {
-    return (HasFlags(A, Modifier_Flag_Control) == HasFlags(B, Modifier_Flag_Control));
+    if(HasFlags(A, Modifier_Flag_Control))
+    {
+        return (HasFlags(B, Modifier_Flag_LControl) ||
+                HasFlags(B, Modifier_Flag_RControl) ||
+                HasFlags(B, Modifier_Flag_Control));
+    }
+    else
+    {
+        return ((HasFlags(A, Modifier_Flag_LControl) == HasFlags(B, Modifier_Flag_LControl)) &&
+                (HasFlags(A, Modifier_Flag_RControl) == HasFlags(B, Modifier_Flag_RControl)) &&
+                (HasFlags(A, Modifier_Flag_Control) == HasFlags(B, Modifier_Flag_Control)));
+    }
 }
 
 internal void
@@ -106,6 +117,10 @@ ParseModifiers(modifier_keys *Modifier, std::string KeySym)
             AddFlags(Modifier, Modifier_Flag_RShift);
         else if(Modifiers[ModIndex] == "ctrl")
             AddFlags(Modifier, Modifier_Flag_Control);
+        else if(Modifiers[ModIndex] == "lctrl")
+            AddFlags(Modifier, Modifier_Flag_LControl);
+        else if(Modifiers[ModIndex] == "rctrl")
+            AddFlags(Modifier, Modifier_Flag_RControl);
     }
 }
 
@@ -146,7 +161,14 @@ ModifierFromCGEvent(CGEventRef Event)
     }
 
     if((Flags & Event_Mask_Control) == Event_Mask_Control)
-        AddFlags(&Modifier, Modifier_Flag_Control);
+    {
+        if((Flags & Event_Mask_LControl) == Event_Mask_LControl)
+            AddFlags(&Modifier, Modifier_Flag_LControl);
+        else if((Flags & Event_Mask_RControl) == Event_Mask_RControl)
+            AddFlags(&Modifier, Modifier_Flag_RControl);
+        else
+            AddFlags(&Modifier, Modifier_Flag_Control);
+    }
 
     return Modifier;
 }

--- a/kwm/keys.h
+++ b/kwm/keys.h
@@ -24,6 +24,8 @@ enum osx_event_mask
     Event_Mask_RCmd = 0x00000010,
 
     Event_Mask_Control = 0x00040000,
+    Event_Mask_LControl = 0x00000001,
+    Event_Mask_RControl = 0x00002000,
 };
 
 enum modifier_flag
@@ -41,6 +43,8 @@ enum modifier_flag
     Modifier_Flag_RCmd = (1 << 8),
 
     Modifier_Flag_Control = (1 << 9),
+    Modifier_Flag_LControl = (1 << 10),
+    Modifier_Flag_RControl = (1 << 11),
 };
 
 bool MouseDragKeyMatchesCGEvent(CGEventRef Event);


### PR DESCRIPTION
Lemme know if I did anything dumb here. Added support because there are external keyboards that have left and right control. Personally using caps > rctrl as a replacement for caps > cmd+alt+ctrl since Seil and Karabiner aren't updated for Sierra.
