### PR TITLE
Fix compilation with Xcode 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8
 script: make install
 notifications:
     irc:

--- a/makefile
+++ b/makefile
@@ -1,8 +1,7 @@
 DEBUG_BUILD   = -DDEBUG_BUILD -g
 FRAMEWORKS    = -framework ApplicationServices -framework Carbon -framework Cocoa
 DEVELOPER_DIR = $(shell xcode-select -p)
-SWIFT_STATIC  = $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift_static/macosx
-SDK_ROOT      = $(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
+SDK_ROOT      = $(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 KWM_SRCS      = kwm/kwm.cpp kwm/container.cpp kwm/node.cpp kwm/tree.cpp kwm/window.cpp kwm/display.cpp \
 				kwm/daemon.cpp kwm/interpreter.cpp kwm/keys.cpp kwm/space.cpp kwm/border.cpp kwm/cursor.cpp \
 				kwm/serializer.cpp kwm/tokenizer.cpp kwm/rules.cpp kwm/scratchpad.cpp kwm/config.cpp kwm/query.cpp \
@@ -63,15 +62,11 @@ $(OBJS_DIR)/kwmc/%.o: kwmc/%.cpp
 	g++ -c $< $(BUILD_FLAGS) -o $@
 
 $(BUILD_PATH)/kwm-overlay: $(foreach obj,$(KWMO_OBJS),$(OBJS_DIR)/$(obj))
-	swiftc $^ -lc++ -L $(SWIFT_STATIC) -Xlinker -force_load_swift_libs -o $@
+	swiftc $^ -static-stdlib -sdk $(SDK_ROOT) -o $@
 
 $(OBJS_DIR)/kwm-overlay/%.o: kwm-overlay/%.swift
 	@mkdir -p $(@D)
 	swiftc -c $^ $(DEBUG_BUILD) -sdk $(SDK_ROOT) -o $@
-
-$(OBJS_DIR)/kwm-overlay/%.o: kwm-overlay/%.mm
-	@mkdir -p $(@D)
-	g++ -c $^ $(DEBUG_BUILD) $(BUILD_FLAGS) -o $@
 
 $(BUILD_PATH)/kwm_template.plist: $(KWM_PLIST)
 	cp $^ $@


### PR DESCRIPTION
Xcode 8 renamed the SDK and also switched to Swift 3.
We can also remove hacky flags for kwm-overlay since static linking is
now officially supported.
N.B. the conversion was done automatically by Xcode since I don't know anything about swift 3, but it seems to work <.<
N.B. Not sure if this allows compilation on Sierra, haven't installed it yet and won't until the end of the month