### PR TITLE
Drag between displays

### DIFF
--- a/kwm/cursor.cpp
+++ b/kwm/cursor.cpp
@@ -5,6 +5,7 @@
 #include "space.h"
 #include "border.h"
 #include "../axlib/axlib.h"
+#include "display.h"
 
 #define internal static
 extern std::map<std::string, space_info> WindowTree;
@@ -76,13 +77,19 @@ EVENT_CALLBACK(Callback_AXEvent_LeftMouseUp)
          * and its Focus can never be NULL here. */
 
         ax_window *Window = FocusedApplication->Focus;
-        if(MarkedNode && MarkedNode->WindowID != Window->ID)
-        {
-            ax_display *Display = AXLibWindowDisplay(Window);
-            tree_node *Node = GetTreeNodeFromWindowIDOrLinkNode(WindowTree[Display->Space->Identifier].RootNode, Window->ID);
-            if(Node)
+        ax_display *WindowDisplay = AXLibWindowDisplay(Window);
+        ax_display *CursorDisplay = AXLibCursorDisplay();
+        
+        if (WindowDisplay != CursorDisplay) {
+            MoveWindowToDisplay(Window, CursorDisplay);
+        } else {
+            if(MarkedNode && MarkedNode->WindowID != Window->ID)
             {
-                SwapNodeWindowIDs(Node, MarkedNode);
+                tree_node *Node = GetTreeNodeFromWindowIDOrLinkNode(WindowTree[WindowDisplay->Space->Identifier].RootNode, Window->ID);
+                if(Node)
+                {
+                    SwapNodeWindowIDs(Node, MarkedNode);
+                }
             }
         }
 
@@ -111,7 +118,7 @@ EVENT_CALLBACK(Callback_AXEvent_LeftMouseDragged)
         }
         else
         {
-            ax_display *Display = AXLibWindowDisplay(Window);
+            ax_display *Display = AXLibCursorDisplay();
             tree_node *NewNode = GetTreeNodeForPoint(WindowTree[Display->Space->Identifier].RootNode, Cursor);
             if(NewNode && NewNode != MarkedNode)
             {

--- a/kwm/cursor.cpp
+++ b/kwm/cursor.cpp
@@ -118,8 +118,17 @@ EVENT_CALLBACK(Callback_AXEvent_LeftMouseDragged)
         }
         else
         {
-            ax_display *Display = AXLibCursorDisplay();
-            tree_node *NewNode = GetTreeNodeForPoint(WindowTree[Display->Space->Identifier].RootNode, Cursor);
+            ax_display *CursorDisplay = AXLibCursorDisplay();
+            ax_display *WindowDisplay = AXLibWindowDisplay(Window);
+            tree_node *NewNode;
+            if (WindowDisplay != CursorDisplay)
+            {
+                NewNode = WindowTree[CursorDisplay->Space->Identifier].RootNode;
+            }
+            else
+            {
+                NewNode = GetTreeNodeForPoint(WindowTree[WindowDisplay->Space->Identifier].RootNode, Cursor);
+            }
             if(NewNode && NewNode != MarkedNode)
             {
                 MarkedNode = NewNode;

--- a/kwm/display.cpp
+++ b/kwm/display.cpp
@@ -137,6 +137,21 @@ void MoveWindowToDisplay(ax_window *Window, ax_display *NewDisplay)
     }
 }
 
+void RemoveWindowFromOtherDisplays(ax_window *Window)
+{
+    ax_display *WindowDisplay = AXLibWindowDisplay(Window);
+    
+    ax_display *MainDisplay = AXLibMainDisplay();
+    ax_display *Display = MainDisplay;
+    do
+    {
+        if(Display != WindowDisplay) {
+            RemoveWindowFromNodeTree(Display, Window->ID);
+        }
+        Display = AXLibNextDisplay(Display);
+    } while(Display != MainDisplay);
+}
+
 space_settings *GetSpaceSettingsForDisplay(unsigned int ScreenID)
 {
     std::map<unsigned int, space_settings>::iterator It = KWMSettings.DisplaySettings.find(ScreenID);

--- a/kwm/display.cpp
+++ b/kwm/display.cpp
@@ -104,6 +104,13 @@ void MoveWindowToDisplay(ax_window *Window, int Shift, bool Relative)
         NewDisplay = Shift == 1 ? AXLibNextDisplay(Display) : AXLibPreviousDisplay(Display);
     else
         NewDisplay = AXLibArrangementDisplay(Shift);
+    MoveWindowToDisplay(Window, NewDisplay);
+}
+
+void MoveWindowToDisplay(ax_window *Window, ax_display *NewDisplay)
+{
+    ax_display *Display = AXLibWindowDisplay(Window);
+
 
     if(NewDisplay && NewDisplay != Display)
     {

--- a/kwm/display.h
+++ b/kwm/display.h
@@ -12,6 +12,7 @@ void ChangeGapOfDisplay(const std::string &Side, int Offset);
 space_settings *GetSpaceSettingsForDisplay(unsigned int ScreenID);
 container_offset CreateDefaultDisplayOffset();
 void MoveWindowToDisplay(ax_window *Window, int Shift, bool Relative);
+void MoveWindowToDisplay(ax_window *Window, ax_display *NewDisplay);
 void FocusDisplay(ax_display *Display);
 
 #endif

--- a/kwm/display.h
+++ b/kwm/display.h
@@ -13,6 +13,7 @@ space_settings *GetSpaceSettingsForDisplay(unsigned int ScreenID);
 container_offset CreateDefaultDisplayOffset();
 void MoveWindowToDisplay(ax_window *Window, int Shift, bool Relative);
 void MoveWindowToDisplay(ax_window *Window, ax_display *NewDisplay);
+void RemoveWindowFromOtherDisplays(ax_window *Window);
 void FocusDisplay(ax_display *Display);
 
 #endif

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -486,6 +486,9 @@ EVENT_CALLBACK(Callback_AXEvent_WindowMoved)
 
         if(!Event->Intrinsic && HasFlags(&KWMSettings, Settings_LockToContainer))
             LockWindowToContainerSize(Window);
+        
+        if (!Event->Intrinsic)
+            RemoveWindowFromOtherDisplays(Window);
 
         ax_display *Display = AXLibWindowDisplay(Window);
         if((FocusedApplication == Window->Application) &&


### PR DESCRIPTION
This allows mod-move -ing windows between displays, and seems to work quite well. When moving a window within a display, current behaviour (swap with hover target) is preserved, but when moving to another display, the window is moved to that display's tree with no swap occurring, as anecdotally this seems to be a more intuitive behaviour.
Highlight behaviour is also amended to try and indicate the impending action - when moving a window to a new display, the root node of that display's current space is highlighted instead of the currently hovered window.
Finally, I've implemented RemoveWindowFromOtherDisplays, so when windows are moved by actions external to kwm, we do a quick sanity check and remove any empty gaps where that window used to be. This actually means that OS X native dragging of windows between displays seems to work quite nicely. (Mission Control-initiated moves are still an effective no-op though.)

I'd love some feedback and a good eye over this as my C++ is not the best. Some specific points I'm not sure about:
 - Highlighting a new display does not work if that display is empty. I would guess that because the root node of that space doesn't exist unless it contains one or more windows, but I don't know enough about kwm to be sure.