### PR TITLE
Update README with note about khd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **NOTE:** The master branch is considered stable and can be used instead of the latest release version by people who wish to do so.
 
+If you building from source on the master branch [khd](https://github.com/koekeishiya/khd) is required in order to allow key-bindings to control kwm.
+
 [**Kwm**](https://koekeishiya.github.io/kwm) started as a simple project to get true focus-follows-mouse support on OSX through event tapping.
 It is now a tiling window manager that represents windows as the leaves of a binary tree.
 *Kwm* supports binary space partitioned, monocle and floating spaces.


### PR DESCRIPTION
Builds from the master branch require kdh now as of https://github.com/koekeishiya/kwm/commit/e53f52a2267b9318d85ed5f2a5a81dbdd3aa8b4c

This PR makes a note in the README with a link to khd and a note about khd being required to allow keybindings to control kwm.