### PR TITLE
Small fixes

### DIFF
--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -378,6 +378,7 @@ EVENT_CALLBACK(Callback_AXEvent_WindowDestroyed)
         ax_display *Display = AXLibWindowDisplay(Window);
         RemoveWindowFromScratchpad(Window);
         RemoveWindowFromNodeTree(Display, Window->ID);
+        RebalanceNodeTree(Display);
 
         if(FocusedApplication == Window->Application)
         {
@@ -1726,7 +1727,7 @@ void CenterWindowInsideNodeContainer(ax_window *Window, int *Xptr, int *Yptr, in
     int XDiff = (X + Width) - (WindowOrigin.x + WindowOGSize.width);
     int YDiff = (Y + Height) - (WindowOrigin.y + WindowOGSize.height);
 
-    if(XDiff > 0 || YDiff > 0)
+    if(abs(XDiff) > 0 || abs(YDiff) > 0)
     {
         double XOff = XDiff / 2.0f;
         X += XOff > 0 ? XOff : 0;


### PR DESCRIPTION
I had those two fixes inside my fork for quite a long time and I haven't noticed any issue.
The first change triggers a tree rebalance on window destruction. This is necessary sometime when using the native osx fullscreen apps since some of them (especially video players) just recreate the window when entereing and leaving fullscreen, leaving the window tree in a broken status.
The second change just takes also in account when the window is bigger than the container thus trying to center it anyway, fixes centering for some windows in my case.