### PR TITLE
Focus by application name.

### DIFF
--- a/kwm/config.cpp
+++ b/kwm/config.cpp
@@ -934,7 +934,7 @@ KwmParseWindowOption(tokenizer *Tokenizer)
             else if(Selector.Type == Token_Digit)
                 FocusWindowByID(ConvertStringToUint(std::string(Selector.Text, Selector.TextLength)));
             else
-                ReportInvalidCommand("Unknown selector '" + std::string(Selector.Text, Selector.TextLength) + "'");
+                FocusWindowByName(std::string(Selector.Text, Selector.TextLength));
         }
         else if(TokenEquals(Token, "fm"))
         {

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -1663,6 +1663,20 @@ void FocusWindowByID(uint32_t WindowID)
     }
 }
 
+void FocusWindowByName(std::string AppName)
+{
+    std::vector<ax_window*> Windows = AXLibGetAllKnownWindows();
+    for(int Index = 0; Index < Windows.size(); ++Index)
+    {
+        ax_window *Window = Windows[Index];
+        if(Window->Application->Name == AppName)
+        {
+            FocusWindowByID(Window->ID);
+            return;
+        }
+    }
+}
+
 void ClearMarkedWindow()
 {
     MarkedWindow = NULL;

--- a/kwm/window.h
+++ b/kwm/window.h
@@ -22,6 +22,7 @@ bool FindClosestWindow(int Degrees, ax_window **ClosestWindow, bool Wrap);
 void CenterWindow(ax_display *Display, ax_window *Window);
 
 void FocusWindowByID(uint32_t WindowID);
+void FocusWindowByName(std::string AppName);
 void ToggleWindowFloating(uint32_t WindowID, bool Center);
 void ToggleFocusedWindowFloating();
 void ToggleFocusedWindowParentContainer();


### PR DESCRIPTION
Focus window by application name, e.g. `kwmc window -f Emacs`

If the application is not open, ignore the command.