### PR TITLE
Check if window is in fullscreen before resizing

### DIFF
--- a/axlib/element.cpp
+++ b/axlib/element.cpp
@@ -64,6 +64,20 @@ bool AXLibIsWindowMovable(AXUIElementRef WindowRef)
     return Result;
 }
 
+bool AXLibIsWindowFullscreen(AXUIElementRef WindowRef)
+{
+    bool Result = false;
+
+    CFBooleanRef Value = (CFBooleanRef) AXLibGetWindowProperty(WindowRef, kAXFullscreenAttribute);
+    if(Value)
+    {
+        Result = CFBooleanGetValue(Value);
+        CFRelease(Value);
+    }
+
+    return Result;
+}
+
 bool AXLibIsWindowResizable(AXUIElementRef WindowRef)
 {
     bool Result;

--- a/axlib/element.h
+++ b/axlib/element.h
@@ -3,12 +3,15 @@
 
 #include <Carbon/Carbon.h>
 
+#define kAXFullscreenAttribute CFSTR("AXFullScreen")
+
 extern "C" AXError _AXUIElementGetWindow(AXUIElementRef, uint32_t *WID);
 uint32_t AXLibGetWindowID(AXUIElementRef WindowRef);
 
 bool AXLibIsWindowMinimized(AXUIElementRef WindowRef);
 bool AXLibIsWindowResizable(AXUIElementRef WindowRef);
 bool AXLibIsWindowMovable(AXUIElementRef WindowRef);
+bool AXLibIsWindowFullscreen(AXUIElementRef WindowRef);
 
 bool AXLibSetWindowPosition(AXUIElementRef WindowRef, int X, int Y);
 bool AXLibSetWindowSize(AXUIElementRef WindowRef, int Width, int Height);

--- a/kwm/window.cpp
+++ b/kwm/window.cpp
@@ -1752,27 +1752,31 @@ void CenterWindowInsideNodeContainer(ax_window *Window, int *Xptr, int *Yptr, in
 
 void SetWindowDimensions(ax_window *Window, int X, int Y, int Width, int Height)
 {
-    bool Changed = false;
-    if((Window->Position.x != X) ||
-       (Window->Position.y != Y))
+    if(!AXLibIsWindowFullscreen(Window->Ref))
     {
-        Changed = true;
-        AXLibAddFlags(Window, AXWindow_MoveIntrinsic);
-        if(!AXLibSetWindowPosition(Window->Ref, X, Y))
-            AXLibClearFlags(Window, AXWindow_MoveIntrinsic);
-    }
+        bool Changed = false;
 
-    if((Window->Size.width != Width) ||
-       (Window->Size.height != Height))
-    {
-        Changed = true;
-        AXLibAddFlags(Window, AXWindow_SizeIntrinsic);
-        if(!AXLibSetWindowSize(Window->Ref, Width, Height))
-            AXLibClearFlags(Window, AXWindow_SizeIntrinsic);
-    }
+        if((Window->Position.x != X) ||
+           (Window->Position.y != Y))
+        {
+            Changed = true;
+            AXLibAddFlags(Window, AXWindow_MoveIntrinsic);
+            if(!AXLibSetWindowPosition(Window->Ref, X, Y))
+                AXLibClearFlags(Window, AXWindow_MoveIntrinsic);
+        }
 
-    if(Changed)
-        CenterWindowInsideNodeContainer(Window, &X, &Y, &Width, &Height);
+        if((Window->Size.width != Width) ||
+           (Window->Size.height != Height))
+        {
+            Changed = true;
+            AXLibAddFlags(Window, AXWindow_SizeIntrinsic);
+            if(!AXLibSetWindowSize(Window->Ref, Width, Height))
+                AXLibClearFlags(Window, AXWindow_SizeIntrinsic);
+        }
+
+        if(Changed)
+            CenterWindowInsideNodeContainer(Window, &X, &Y, &Width, &Height);
+    }
 }
 
 void CenterWindow(ax_display *Display, ax_window *Window)

--- a/overlaylib/overlaylib.swift
+++ b/overlaylib/overlaylib.swift
@@ -63,36 +63,10 @@ class OverlayWindow
 		window.isReleasedWhenClosed = false
 
 		overlayView = OverlayView(frame: window.contentView!.bounds, borderColor: borderColor, borderWidth: borderWidth, cornerRadius: cornerRadius)
-		overlayView.translatesAutoresizingMaskIntoConstraints = false
-
+		overlayView.autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
 		window.contentView!.addSubview(overlayView)
 
-		window.contentView!.addConstraint(
-			NSLayoutConstraint(
-				item: overlayView,
-				attribute: .width,
-				relatedBy: .equal,
-				toItem: window.contentView!,
-				attribute: .width,
-				multiplier: 1,
-				constant: 0
-			)
-		)
-
-		window.contentView!.addConstraint(
-			NSLayoutConstraint(
-				item: overlayView,
-				attribute: .height,
-				relatedBy: .equal,
-				toItem: window.contentView!,
-				attribute: .height,
-				multiplier: 1,
-				constant: 0
-			)
-		)
-
 		updateFrame()
-
 		window.makeKeyAndOrderFront(nil)
 
 	}


### PR DESCRIPTION
Added new method that uses undocumented attribute to check if window is fullscreen. 
Checking the type of the space in this case didn't work, probably because the dimensions were changed even before updating the space infos.

This fixes https://github.com/koekeishiya/kwm/issues/524 and also probably related issues with fullscreen when window was resized like it was tiling.
The check could also be placed as a guard before the call to `LockToContainerSize` in the `AXEvent_WindowResized` callback and still fix the issue, but I preferred to put it here. If you have a different opinion let me know.

EDIT: I also changed back to autoresizing masks from auto layout in overlaylib since there were warnings with the latter.