### PR TITLE
Added 'owner' queries for focused and marked windows

### DIFF
--- a/kwm/config.cpp
+++ b/kwm/config.cpp
@@ -1496,6 +1496,8 @@ KwmParseQueryOption(tokenizer *Tokenizer)
             token Token = GetToken(Tokenizer);
             if(TokenEquals(Token, "id"))
                 KwmConstructEvent(KWMEvent_QueryFocusedWindowId, KwmCreateContext(ClientSockFD));
+            else if(TokenEquals(Token, "owner"))
+                KwmConstructEvent(KWMEvent_QueryFocusedWindowOwner, KwmCreateContext(ClientSockFD));
             else if(TokenEquals(Token, "name"))
                 KwmConstructEvent(KWMEvent_QueryFocusedWindowName, KwmCreateContext(ClientSockFD));
             else if(TokenEquals(Token, "split"))
@@ -1526,6 +1528,8 @@ KwmParseQueryOption(tokenizer *Tokenizer)
             token Token = GetToken(Tokenizer);
             if(TokenEquals(Token, "id"))
                 KwmConstructEvent(KWMEvent_QueryMarkedWindowId, KwmCreateContext(ClientSockFD));
+            else if(TokenEquals(Token, "owner"))
+                KwmConstructEvent(KWMEvent_QueryMarkedWindowOwner, KwmCreateContext(ClientSockFD));
             else if(TokenEquals(Token, "name"))
                 KwmConstructEvent(KWMEvent_QueryMarkedWindowName, KwmCreateContext(ClientSockFD));
             else if(TokenEquals(Token, "split"))

--- a/kwm/event.h
+++ b/kwm/event.h
@@ -28,11 +28,13 @@ extern EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedBorder);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedBorder);
 
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowId);
+extern EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowOwner);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowName);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowSplit);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowFloat);
 
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowId);
+extern EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowOwner);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowName);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowSplit);
 extern EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowFloat);
@@ -69,11 +71,13 @@ enum kwm_event_type
     KWMEvent_QueryMarkedBorder,
 
     KWMEvent_QueryFocusedWindowId,
+    KWMEvent_QueryFocusedWindowOwner,
     KWMEvent_QueryFocusedWindowName,
     KWMEvent_QueryFocusedWindowSplit,
     KWMEvent_QueryFocusedWindowFloat,
 
     KWMEvent_QueryMarkedWindowId,
+    KWMEvent_QueryMarkedWindowOwner,
     KWMEvent_QueryMarkedWindowName,
     KWMEvent_QueryMarkedWindowSplit,
     KWMEvent_QueryMarkedWindowFloat,

--- a/kwm/query.cpp
+++ b/kwm/query.cpp
@@ -308,6 +308,17 @@ EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowId)
     free(SockFD);
 }
 
+EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowOwner)
+{
+    int *SockFD = (int *) Event->Context;
+
+
+    ax_application *Application = AXLibGetFocusedApplication();
+    std::string Output = Application && Application->Focus ? Application->Name : "";
+    KwmWriteToSocket(Output, *SockFD);
+    free(SockFD);
+}
+
 EVENT_CALLBACK(Callback_KWMEvent_QueryFocusedWindowName)
 {
     int *SockFD = (int *) Event->Context;
@@ -344,6 +355,15 @@ EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowId)
     int *SockFD = (int *) Event->Context;
 
     std::string Output = MarkedWindow ? std::to_string(MarkedWindow->ID) : "-1";
+    KwmWriteToSocket(Output, *SockFD);
+    free(SockFD);
+}
+
+EVENT_CALLBACK(Callback_KWMEvent_QueryMarkedWindowOwner)
+{
+    int *SockFD = (int *) Event->Context;
+
+    std::string Output = MarkedWindow && MarkedWindow->Application ? MarkedWindow->Application->Name : "";
     KwmWriteToSocket(Output, *SockFD);
     free(SockFD);
 }


### PR DESCRIPTION
More specifically, this adds support for:
```
❯ kwmc query window focused owner
iTerm2

❯ kwmc query window marked owner
iTerm2
```

Not sure whether this is the ideal name to use for the command - I picked it because it matched the convention used for rules.

I want this so that I can programmatically display text that looks like: `${APPLICATION}: ${WINDOW}`

To test this, I've built the code locally and run both commands, both with and without marked and focused windows.